### PR TITLE
feat(runtime): live AST watcher & delta-memory sessions

### DIFF
--- a/graphify_plus/__main__.py
+++ b/graphify_plus/__main__.py
@@ -108,6 +108,30 @@ def main(argv: list[str] | None = None) -> int:
             return int(e.code or 0)
         return 0
 
+    if cmd == "watch":
+        from graphify_plus.interface.cli.watch_cmd import watch_cmd
+        try:
+            watch_cmd.main(args=rest, prog_name="graphify-plus watch",
+                           standalone_mode=False)
+        except SystemExit as e:
+            return int(e.code or 0)
+        except click.ClickException as e:
+            e.show()
+            return 1
+        return 0
+
+    if cmd == "session":
+        from graphify_plus.interface.cli.session_cmd import session_cmd
+        try:
+            session_cmd.main(args=rest, prog_name="graphify-plus session",
+                             standalone_mode=False)
+        except SystemExit as e:
+            return int(e.code or 0)
+        except click.ClickException as e:
+            e.show()
+            return 1
+        return 0
+
     if cmd == "skeleton":
         from graphify_plus.interface.cli.skeleton_cmd import skeleton_cmd
         try:

--- a/graphify_plus/interface/cli/session_cmd.py
+++ b/graphify_plus/interface/cli/session_cmd.py
@@ -1,0 +1,109 @@
+"""``gp session`` — start / status / delta / prune.
+
+Sessions track which skeleton hashes the AI has already received in the
+current conversation. ``gp context`` (Phase 3) consults the session to
+ship deltas instead of full re-sends.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import click
+
+from ...runtime.session import Session, prune_expired
+from ...runtime.store import Store, cache_path
+
+
+def _open(repo: Path) -> Store:
+    repo = repo.resolve()
+    if not cache_path(repo).exists():
+        raise click.ClickException(
+            f"No cache at {cache_path(repo)}. Run 'graphify-plus init --repo {repo}' first."
+        )
+    return Store(cache_path(repo))
+
+
+@click.group("session")
+@click.option(
+    "--repo",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    default=Path("."),
+)
+@click.pass_context
+def session_cmd(ctx: click.Context, repo: Path) -> None:
+    """Per-conversation session bookkeeping for Delta-Memory."""
+    ctx.ensure_object(dict)
+    ctx.obj["repo"] = repo
+
+
+@session_cmd.command("start")
+@click.option("--id", "session_id", default=None, help="Reuse a specific session id.")
+@click.pass_context
+def session_start(ctx: click.Context, session_id: str | None) -> None:
+    """Start a new session and print its id."""
+    store = _open(ctx.obj["repo"])
+    try:
+        s = Session.start(store, session_id=session_id)
+    finally:
+        store.close()
+    click.echo(s.id)
+
+
+@session_cmd.command("status")
+@click.argument("session_id")
+@click.pass_context
+def session_status(ctx: click.Context, session_id: str) -> None:
+    store = _open(ctx.obj["repo"])
+    try:
+        s = Session.start(store, session_id=session_id)
+        click.echo(json.dumps(s.status(), indent=2))
+    finally:
+        store.close()
+
+
+@session_cmd.command("delta")
+@click.argument("session_id")
+@click.option(
+    "--hashes",
+    default=None,
+    help="Comma-separated skeleton hashes (or read JSON list from stdin if omitted).",
+)
+@click.pass_context
+def session_delta(ctx: click.Context, session_id: str, hashes: str | None) -> None:
+    """Compute (already_seen, new) for the supplied hashes and record the
+    new ones as touched."""
+    if hashes:
+        wanted = [h.strip() for h in hashes.split(",") if h.strip()]
+    else:
+        wanted = json.loads(sys.stdin.read() or "[]")
+    store = _open(ctx.obj["repo"])
+    try:
+        s = Session.start(store, session_id=session_id)
+        seen, new = s.delta(wanted)
+        s.touch_many(new)
+        click.echo(
+            json.dumps(
+                {"already_seen": sorted(seen), "new": sorted(new)},
+                indent=2,
+            )
+        )
+    finally:
+        store.close()
+
+
+@session_cmd.command("prune")
+@click.pass_context
+def session_prune(ctx: click.Context) -> None:
+    """Delete session rows older than 24 h."""
+    store = _open(ctx.obj["repo"])
+    try:
+        n = prune_expired(store)
+    finally:
+        store.close()
+    click.echo(f"pruned {n} expired session rows")
+
+
+__all__ = ["session_cmd"]

--- a/graphify_plus/interface/cli/watch_cmd.py
+++ b/graphify_plus/interface/cli/watch_cmd.py
@@ -1,0 +1,69 @@
+"""``gp watch`` — run the live watcher in the foreground, emitting JSONL events."""
+
+from __future__ import annotations
+
+import signal
+import sys
+import threading
+from pathlib import Path
+
+import click
+import orjson
+
+from ...runtime.store import cache_path
+from ...runtime.watcher import FileUpdate, Watcher
+
+
+@click.command("watch")
+@click.option(
+    "--repo",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    default=Path("."),
+    help="Target repository root (defaults to cwd).",
+)
+def watch_cmd(repo: Path) -> None:
+    """Watch the target repo for source-file edits and incrementally
+    update the symbol graph. Emits one JSONL event per applied update.
+    """
+    repo = repo.resolve()
+    if not cache_path(repo).exists():
+        raise click.ClickException(
+            f"No cache at {cache_path(repo)}. Run 'graphify-plus init --repo {repo}' first."
+        )
+
+    stopped = threading.Event()
+
+    def _on_update(u: FileUpdate) -> None:
+        sys.stdout.buffer.write(
+            orjson.dumps(
+                {
+                    "event": "updated",
+                    "path": u.path,
+                    "added": u.added,
+                    "removed": u.removed,
+                    "changed": u.changed,
+                    "elapsed_ms": round(u.elapsed_ms, 2),
+                },
+                option=orjson.OPT_SORT_KEYS | orjson.OPT_APPEND_NEWLINE,
+            )
+        )
+        sys.stdout.flush()
+
+    w = Watcher(repo)
+    w.subscribe(_on_update)
+    w.start()
+
+    def _shutdown(signum, frame):  # noqa: ARG001
+        stopped.set()
+
+    signal.signal(signal.SIGINT, _shutdown)
+    signal.signal(signal.SIGTERM, _shutdown)
+
+    click.echo(f"gp watch: watching {repo} (Ctrl-C to stop)", err=True)
+    try:
+        stopped.wait()
+    finally:
+        w.stop()
+
+
+__all__ = ["watch_cmd"]

--- a/graphify_plus/runtime/session.py
+++ b/graphify_plus/runtime/session.py
@@ -1,0 +1,96 @@
+"""Delta-Memory: per-session record of which skeleton hashes the AI
+already received, so subsequent ``gp context`` queries can ship deltas
+instead of full re-sends.
+
+Backed by the ``sessions`` table introduced in Phase 0 (with ``created_at``
+column added here). Sessions auto-expire after 24 hours.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from .store import Store
+
+SESSION_TTL_SEC = 24 * 60 * 60
+
+
+def _ensure_schema(store: Store) -> None:
+    """Add timestamp column to sessions table if missing (one-shot migration)."""
+    cols = {row[1] for row in store.conn.execute("PRAGMA table_info(sessions)").fetchall()}
+    if "created_at" not in cols:
+        store.conn.execute("ALTER TABLE sessions ADD COLUMN created_at INTEGER DEFAULT 0")
+
+
+@dataclass
+class Session:
+    """A token-saving session. Records which skeleton hashes the AI has
+    already seen in this conversation."""
+
+    id: str
+    store: Store
+
+    # ---- factory --------------------------------------------------------
+    @classmethod
+    def start(cls, store: Store, session_id: str | None = None) -> Session:
+        _ensure_schema(store)
+        sid = session_id or str(uuid.uuid4())
+        # Create a sentinel row so the session exists even before any touch.
+        store.conn.execute(
+            "INSERT OR IGNORE INTO sessions(id, hash, created_at) VALUES(?, ?, ?)",
+            (sid, "__sentinel__", int(time.time())),
+        )
+        return cls(id=sid, store=store)
+
+    # ---- recording ------------------------------------------------------
+    def touch(self, skeleton_hash: str) -> None:
+        self.store.conn.execute(
+            "INSERT OR IGNORE INTO sessions(id, hash, created_at) VALUES(?, ?, ?)",
+            (self.id, skeleton_hash, int(time.time())),
+        )
+
+    def touch_many(self, hashes: Iterable[str]) -> None:
+        rows = [(self.id, h, int(time.time())) for h in hashes]
+        if rows:
+            self.store.conn.executemany(
+                "INSERT OR IGNORE INTO sessions(id, hash, created_at) VALUES(?, ?, ?)",
+                rows,
+            )
+
+    # ---- delta ----------------------------------------------------------
+    def delta(self, needed: Iterable[str]) -> tuple[set[str], set[str]]:
+        """Return ``(already_seen, new)`` for the requested skeleton hashes."""
+        wanted = set(needed)
+        if not wanted:
+            return set(), set()
+        placeholders = ",".join(["?"] * len(wanted))
+        rows = self.store.conn.execute(
+            f"SELECT hash FROM sessions WHERE id = ? AND hash IN ({placeholders})",
+            (self.id, *wanted),
+        ).fetchall()
+        seen = {r[0] for r in rows}
+        return seen, wanted - seen
+
+    def status(self) -> dict[str, int | str]:
+        row = self.store.conn.execute(
+            "SELECT COUNT(*) - 1, MIN(created_at) FROM sessions WHERE id = ?",
+            (self.id,),
+        ).fetchone()
+        return {
+            "id": self.id,
+            "hashes_seen": max(0, int(row[0] or 0)),
+            "started_at": int(row[1] or 0),
+        }
+
+
+def prune_expired(store: Store, *, ttl_sec: int = SESSION_TTL_SEC) -> int:
+    _ensure_schema(store)
+    cutoff = int(time.time()) - ttl_sec
+    cur = store.conn.execute("DELETE FROM sessions WHERE created_at < ?", (cutoff,))
+    return cur.rowcount or 0
+
+
+__all__ = ["Session", "prune_expired"]

--- a/graphify_plus/runtime/watcher.py
+++ b/graphify_plus/runtime/watcher.py
@@ -1,0 +1,290 @@
+"""Live AST watcher.
+
+Watches the target repo's source tree. On any save it:
+
+  1. Re-parses *only* the changed file with the appropriate adapter.
+  2. Computes the symbol delta against the cached state.
+  3. Writes the delta into SQLite in a single transaction.
+  4. Re-skeletonises changed symbols and updates the CAS + symbol→hash
+     map.
+  5. Notifies subscribers (used by Phase 5's sync-docs daemon).
+
+Latency budget: ≤80 ms p95 per single-file save (small file, warm cache).
+
+Design notes
+------------
+- Uses ``watchdog.Observer`` on Linux/Windows. macOS and any path with
+  ``GP_FORCE_POLLING=1`` set falls back to ``PollingObserver`` because
+  kqueue silently drops events on directories with > ~10k inodes.
+- Events are debounced at 250 ms per path — many editors save twice (a
+  temp file then atomic rename) and we only want to re-parse once.
+- Tests must NOT use ``time.sleep`` for synchronisation. The watcher
+  exposes a ``wait_for_path`` helper backed by ``threading.Event``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from watchdog.events import FileSystemEvent, FileSystemEventHandler
+from watchdog.observers import Observer
+from watchdog.observers.polling import PollingObserver
+
+from ..core import cas
+from ..core.adapters import Edge, Symbol, adapter_for
+from ..core.skeletonizer import skeletonize_all
+from .store import Store, cache_path
+
+log = logging.getLogger("graphify_plus.watcher")
+
+DEBOUNCE_MS = 250
+
+
+@dataclass
+class FileUpdate:
+    """A single observed-and-applied file change."""
+
+    path: str  # repo-relative POSIX
+    added: list[str] = field(default_factory=list)  # symbol ids
+    removed: list[str] = field(default_factory=list)
+    changed: list[str] = field(default_factory=list)
+    elapsed_ms: float = 0.0
+
+
+def _use_polling() -> bool:
+    if os.environ.get("GP_FORCE_POLLING") == "1":
+        return True
+    # macOS kqueue dropouts on large trees → polling is the safer default.
+    import platform
+
+    return platform.system() == "Darwin"
+
+
+class _Debouncer:
+    """Coalesces bursts of events on the same path."""
+
+    def __init__(self, interval_s: float, fn: Callable[[str], None]) -> None:
+        self._interval = interval_s
+        self._fn = fn
+        self._timers: dict[str, threading.Timer] = {}
+        self._lock = threading.Lock()
+
+    def trigger(self, path: str) -> None:
+        with self._lock:
+            existing = self._timers.pop(path, None)
+            if existing is not None:
+                existing.cancel()
+
+            def _fire() -> None:
+                with self._lock:
+                    self._timers.pop(path, None)
+                try:
+                    self._fn(path)
+                except Exception:
+                    log.exception("watcher: handler failed for %s", path)
+
+            t = threading.Timer(self._interval, _fire)
+            t.daemon = True
+            self._timers[path] = t
+            t.start()
+
+    def cancel_all(self) -> None:
+        with self._lock:
+            for t in self._timers.values():
+                t.cancel()
+            self._timers.clear()
+
+
+class _Handler(FileSystemEventHandler):
+    def __init__(self, on_change: Callable[[str], None], repo: Path) -> None:
+        self._on_change = on_change
+        self._repo = repo
+
+    def _maybe_dispatch(self, event_path: str) -> None:
+        try:
+            full = Path(event_path).resolve()
+            rel = full.relative_to(self._repo).as_posix()
+        except (ValueError, OSError):
+            return
+        if adapter_for(full.name) is None:
+            return
+        if ".graphify_plus" in rel:
+            return
+        self._on_change(rel)
+
+    def on_modified(self, event: FileSystemEvent) -> None:
+        if not event.is_directory:
+            self._maybe_dispatch(event.src_path)
+
+    def on_created(self, event: FileSystemEvent) -> None:
+        if not event.is_directory:
+            self._maybe_dispatch(event.src_path)
+
+    def on_deleted(self, event: FileSystemEvent) -> None:
+        if not event.is_directory:
+            self._maybe_dispatch(event.src_path)
+
+    def on_moved(self, event: FileSystemEvent) -> None:
+        # both ends matter
+        if not event.is_directory:
+            src = getattr(event, "src_path", None)
+            dst = getattr(event, "dest_path", None)
+            if src:
+                self._maybe_dispatch(src)
+            if dst:
+                self._maybe_dispatch(dst)
+
+
+class Watcher:
+    """Live watcher orchestrator. Single-process, single-thread reparse.
+
+    Usage::
+
+        w = Watcher(repo_root)
+        w.subscribe(my_callback)
+        w.start()
+        ...
+        w.stop()
+    """
+
+    def __init__(self, repo: Path):
+        self.repo = repo.resolve()
+        self._observer = PollingObserver() if _use_polling() else Observer()
+        self._handler = _Handler(self._enqueue, self.repo)
+        self._debouncer = _Debouncer(DEBOUNCE_MS / 1000, self._handle)
+        self._subs: list[Callable[[FileUpdate], None]] = []
+        self._path_events: dict[str, threading.Event] = {}
+        self._path_events_lock = threading.Lock()
+        self._started = False
+
+    # ---- subscription API ----------------------------------------------
+    def subscribe(self, fn: Callable[[FileUpdate], None]) -> None:
+        self._subs.append(fn)
+
+    def wait_for_path(self, rel_path: str, timeout: float = 5.0) -> bool:
+        """Block until the next FileUpdate for ``rel_path`` is delivered.
+
+        Test-only synchronisation helper — never use ``time.sleep`` for
+        watcher coordination.
+        """
+        with self._path_events_lock:
+            ev = self._path_events.setdefault(rel_path, threading.Event())
+        return ev.wait(timeout)
+
+    # ---- lifecycle ------------------------------------------------------
+    def start(self) -> None:
+        if self._started:
+            return
+        self._observer.schedule(self._handler, str(self.repo), recursive=True)
+        self._observer.start()
+        self._started = True
+        log.info("watcher started on %s (polling=%s)", self.repo, _use_polling())
+
+    def stop(self) -> None:
+        if not self._started:
+            return
+        self._debouncer.cancel_all()
+        self._observer.stop()
+        self._observer.join(timeout=5.0)
+        self._started = False
+
+    # ---- internals ------------------------------------------------------
+    def _enqueue(self, rel_path: str) -> None:
+        self._debouncer.trigger(rel_path)
+
+    def _handle(self, rel_path: str) -> None:
+        t0 = time.perf_counter()
+        full = self.repo / rel_path
+        store = Store(cache_path(self.repo))
+        try:
+            existing = store.symbols_in_path(rel_path)
+            old_ids = {s["id"] for s in existing}
+
+            new_syms: list[Symbol] = []
+            new_edges: list[Edge] = []
+            if full.exists():
+                ad = adapter_for(full.name)
+                if ad is not None:
+                    try:
+                        new_syms, new_edges = ad.parse(Path(rel_path), full.read_bytes())
+                    except Exception:
+                        log.exception("watcher: parse failed for %s", rel_path)
+                        return
+
+            new_ids = {s["id"] for s in new_syms}
+            added = sorted(new_ids - old_ids)
+            removed = sorted(old_ids - new_ids)
+            persistent = old_ids & new_ids
+            old_by_id = {s["id"]: s for s in existing}
+            new_by_id = {s["id"]: s for s in new_syms}
+            changed = sorted(sid for sid in persistent if old_by_id[sid] != new_by_id[sid])
+
+            import orjson
+
+            with store.tx():
+                if old_ids:
+                    placeholders = ",".join(["?"] * len(old_ids))
+                    params = tuple(old_ids)
+                    store.conn.execute(f"DELETE FROM symbols WHERE id IN ({placeholders})", params)
+                    store.conn.execute(
+                        f"DELETE FROM symbol_skeletons WHERE symbol_id IN ({placeholders})",
+                        params,
+                    )
+                    store.conn.execute(f"DELETE FROM edges WHERE src IN ({placeholders})", params)
+                if new_syms:
+                    store.conn.executemany(
+                        "INSERT INTO symbols(id, json) VALUES (?, ?)",
+                        [(s["id"], orjson.dumps(s, option=orjson.OPT_SORT_KEYS)) for s in new_syms],
+                    )
+                if new_edges:
+                    store.conn.executemany(
+                        "INSERT INTO edges(src, dst, kind, json) VALUES (?, ?, ?, ?)",
+                        [
+                            (
+                                e["src"],
+                                e["dst"],
+                                e.get("kind") or "",
+                                orjson.dumps(e, option=orjson.OPT_SORT_KEYS),
+                            )
+                            for e in new_edges
+                        ],
+                    )
+
+            # Skeletons (outside the main tx — CAS dedup is idempotent).
+            sk = skeletonize_all(new_syms)
+            for sid, body in sk.items():
+                h = cas.put(store, body)
+                store.link_skeleton(sid, h)
+
+            update = FileUpdate(
+                path=rel_path,
+                added=added,
+                removed=removed,
+                changed=changed,
+                elapsed_ms=(time.perf_counter() - t0) * 1000,
+            )
+        finally:
+            store.close()
+
+        # Fan-out
+        for fn in self._subs:
+            try:
+                fn(update)
+            except Exception:
+                log.exception("watcher subscriber raised")
+
+        with self._path_events_lock:
+            ev = self._path_events.get(rel_path)
+            if ev is not None:
+                ev.set()
+                # Reset for next round-trip.
+                self._path_events[rel_path] = threading.Event()
+
+
+__all__ = ["FileUpdate", "Watcher"]

--- a/tests/runtime/test_session.py
+++ b/tests/runtime/test_session.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from graphify_plus.runtime.session import Session, prune_expired
+from graphify_plus.runtime.store import Store, cache_path
+
+
+def _store(tmp_path: Path) -> Store:
+    return Store(cache_path(tmp_path))
+
+
+def test_session_records_and_diffs(tmp_path: Path):
+    s = _store(tmp_path)
+    try:
+        sess = Session.start(s)
+        seen, new = sess.delta(["aaa", "bbb"])
+        assert seen == set()
+        assert new == {"aaa", "bbb"}
+        sess.touch_many(new)
+        seen, new = sess.delta(["aaa", "bbb"])
+        assert seen == {"aaa", "bbb"}
+        assert new == set()
+    finally:
+        s.close()
+
+
+def test_session_distinct_ids(tmp_path: Path):
+    s = _store(tmp_path)
+    try:
+        a = Session.start(s)
+        b = Session.start(s)
+        assert a.id != b.id
+        a.touch("h1")
+        seen_a, _ = a.delta(["h1"])
+        seen_b, _ = b.delta(["h1"])
+        assert seen_a == {"h1"}
+        assert seen_b == set()
+    finally:
+        s.close()
+
+
+def test_session_prune(tmp_path: Path):
+    s = _store(tmp_path)
+    try:
+        sess = Session.start(s)
+        sess.touch_many(["x", "y", "z"])
+        # Force-age the rows by setting created_at to 0.
+        s.conn.execute("UPDATE sessions SET created_at = 0 WHERE id = ?", (sess.id,))
+        n = prune_expired(s, ttl_sec=1)
+        assert n >= 4  # 3 hashes + sentinel
+    finally:
+        s.close()
+
+
+@given(hashes=st.lists(st.text(min_size=1, max_size=8), min_size=1, max_size=20))
+def test_property_full_resend_yields_empty_delta(hashes, tmp_path_factory):
+    tmp_path = tmp_path_factory.mktemp(f"sess_{int(time.time() * 1e6)}")
+    s = _store(tmp_path)
+    try:
+        sess = Session.start(s)
+        sess.touch_many(hashes)
+        seen, new = sess.delta(hashes)
+        assert new == set()
+        assert seen == set(hashes)
+    finally:
+        s.close()

--- a/tests/runtime/test_watcher.py
+++ b/tests/runtime/test_watcher.py
@@ -1,0 +1,100 @@
+"""Live watcher tests.
+
+Synchronisation rule: NEVER use ``time.sleep`` for watcher coordination.
+Use ``Watcher.wait_for_path`` (threading.Event-backed) — the watcher
+raises that event after the file's update has been fully applied.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from graphify_plus.core import cas
+from graphify_plus.core.ingest import ingest
+from graphify_plus.core.skeletonizer import skeletonize_all
+from graphify_plus.runtime.store import Store, cache_path
+from graphify_plus.runtime.watcher import Watcher
+
+
+def _seed(repo: Path) -> None:
+    """Run an initial ingest so the cache reflects the on-disk state."""
+    res = ingest(repo, parallel=False)
+    skeletons = skeletonize_all(res.symbols)
+    s = Store(cache_path(repo))
+    try:
+        s.replace_all(res.symbols, res.edges)
+        for sid, body in skeletons.items():
+            h = cas.put(s, body)
+            s.link_skeleton(sid, h)
+    finally:
+        s.close()
+
+
+def test_watcher_picks_up_modification(tmp_path: Path):
+    src = tmp_path / "a.py"
+    src.write_text("def foo():\n    return 1\n")
+    _seed(tmp_path)
+
+    w = Watcher(tmp_path)
+    updates: list[str] = []
+    w.subscribe(lambda u: updates.append(u.path))
+    w.start()
+    try:
+        # Edit: add a new function.
+        src.write_text("def foo():\n    return 1\n\ndef bar():\n    return 2\n")
+        assert w.wait_for_path("a.py", timeout=5.0), "watcher did not deliver event"
+    finally:
+        w.stop()
+
+    assert "a.py" in updates
+    s = Store(cache_path(tmp_path))
+    try:
+        qnames = {x["qualified_name"] for x in s.all_symbols()}
+    finally:
+        s.close()
+    assert "a.foo" in qnames
+    assert "a.bar" in qnames
+
+
+def test_watcher_handles_deletion(tmp_path: Path):
+    src = tmp_path / "doomed.py"
+    src.write_text("def gone():\n    return 0\n")
+    _seed(tmp_path)
+
+    w = Watcher(tmp_path)
+    w.start()
+    try:
+        src.unlink()
+        assert w.wait_for_path("doomed.py", timeout=5.0)
+    finally:
+        w.stop()
+
+    s = Store(cache_path(tmp_path))
+    try:
+        qnames = {x["qualified_name"] for x in s.all_symbols()}
+    finally:
+        s.close()
+    assert "doomed.gone" not in qnames
+    assert "doomed" not in qnames  # module symbol gone too
+
+
+def test_watcher_debounces_rapid_writes(tmp_path: Path):
+    src = tmp_path / "noisy.py"
+    src.write_text("def a():\n    return 1\n")
+    _seed(tmp_path)
+
+    w = Watcher(tmp_path)
+    count = {"n": 0}
+    w.subscribe(lambda _u: count.__setitem__("n", count["n"] + 1))
+    w.start()
+    try:
+        # Rapid burst of writes — debounce should coalesce.
+        for i in range(5):
+            src.write_text(f"def a():\n    return {i}\n")
+        assert w.wait_for_path("noisy.py", timeout=5.0)
+    finally:
+        w.stop()
+
+    # Debouncer should have collapsed the burst to ~1 callback.
+    # (May fire 1–2 times depending on filesystem timing, but never 5.)
+    assert 1 <= count["n"] <= 2


### PR DESCRIPTION
Phase 2 of EXECUTION_PLAN.md. Implements Features 3 + 15.

## Summary
- Live watcher: re-parse + delta-apply + skeleton refresh per file save.
- macOS / GP_FORCE_POLLING=1 → PollingObserver (kqueue is unreliable on big trees).
- 250ms per-path debounce coalesces editor save bursts.
- Delta-Memory sessions: per-conversation record of which skeleton hashes the AI has seen, so context queries can ship deltas instead of full re-sends.
- New CLIs: `gp watch`, `gp session start|status|delta|prune`.
- Schema: sessions.created_at column added via one-shot migration.

## Tests
121 passed (+7 new). Watcher tests use threading.Event for sync — never time.sleep.
Hypothesis property: touch(hs) + delta(hs) → (hs, ∅).

## Out of scope
- Watcher reconciliation pass (RESILIENCE_PLAN.md Phase 12)
- Token-budgeted query (Phase 3)