### PR TITLE
feat(query): semantic neighbourhood discovery & dead-code pruning

### DIFF
--- a/graphify_plus/__main__.py
+++ b/graphify_plus/__main__.py
@@ -108,6 +108,30 @@ def main(argv: list[str] | None = None) -> int:
             return int(e.code or 0)
         return 0
 
+    if cmd == "find":
+        from graphify_plus.interface.cli.find_cmd import find_cmd
+        try:
+            find_cmd.main(args=rest, prog_name="graphify-plus find",
+                          standalone_mode=False)
+        except SystemExit as e:
+            return int(e.code or 0)
+        except click.ClickException as e:
+            e.show()
+            return 1
+        return 0
+
+    if cmd == "prune":
+        from graphify_plus.interface.cli.prune_cmd import prune_cmd
+        try:
+            prune_cmd.main(args=rest, prog_name="graphify-plus prune",
+                           standalone_mode=False)
+        except SystemExit as e:
+            return int(e.code or 0)
+        except click.ClickException as e:
+            e.show()
+            return 1
+        return 0
+
     if cmd == "context":
         from graphify_plus.interface.cli.context_cmd import context_cmd
         try:

--- a/graphify_plus/interface/cli/context_cmd.py
+++ b/graphify_plus/interface/cli/context_cmd.py
@@ -22,6 +22,7 @@ import networkx as nx
 from ...core.symbol_graph import build as build_graph
 from ...query.budget import frame_to_budget
 from ...query.partition import compute_partition
+from ...query.prune import report as prune_report
 from ...runtime.store import Store, cache_path
 
 
@@ -71,8 +72,24 @@ def _resolve_target(store: Store, target: str) -> str:
 @click.option("--target", type=str, required=True, help="Symbol name, qualified name, or id.")
 @click.option("--max-tokens", "max_tokens", type=int, default=4000)
 @click.option("--json-manifest", is_flag=True, help="Append a JSON manifest after the context.")
+@click.option(
+    "--apply-prune",
+    is_flag=True,
+    help="Exclude dead-code + orphan symbols from the framed context.",
+)
+@click.option(
+    "--aggressive-prune",
+    is_flag=True,
+    help="Implies --apply-prune; also excludes deprecated symbols.",
+)
 def context_cmd(
-    repo: Path, entry: str | None, target: str, max_tokens: int, json_manifest: bool
+    repo: Path,
+    entry: str | None,
+    target: str,
+    max_tokens: int,
+    json_manifest: bool,
+    apply_prune: bool,
+    aggressive_prune: bool,
 ) -> None:
     """Print a token-budgeted slice of the symbol graph."""
     repo = repo.resolve()
@@ -93,7 +110,10 @@ def context_cmd(
             raise click.ClickException(
                 f"No path from {entry_id} to {target_id}. Try a different entry."
             ) from None
-        framed = frame_to_budget(partition, store, max_tokens=max_tokens)
+        excl: set[str] = set()
+        if apply_prune or aggressive_prune:
+            excl = prune_report(G).all_ids(aggressive=aggressive_prune)
+        framed = frame_to_budget(partition, store, max_tokens=max_tokens, exclude=excl)
         click.echo(framed.text.rstrip("\n"))
         if json_manifest:
             click.echo(

--- a/graphify_plus/interface/cli/find_cmd.py
+++ b/graphify_plus/interface/cli/find_cmd.py
@@ -1,0 +1,71 @@
+"""``gp find`` — natural-language search over the symbol graph.
+
+Default: BM25 over per-community indices, weighted by community density.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import click
+
+from ...core.symbol_graph import build as build_graph
+from ...query.semantic import find as semantic_find
+from ...runtime.store import Store, cache_path
+
+
+@click.command("find")
+@click.option(
+    "--repo",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    default=Path("."),
+)
+@click.option("--intent", "intent", required=True, type=str)
+@click.option("--top", "top_k", default=8, type=int)
+@click.option("--json", "as_json", is_flag=True)
+def find_cmd(repo: Path, intent: str, top_k: int, as_json: bool) -> None:
+    """Find symbols matching a natural-language intent."""
+    repo = repo.resolve()
+    if not cache_path(repo).exists():
+        raise click.ClickException(
+            f"No cache at {cache_path(repo)}. Run 'graphify-plus init --repo {repo}' first."
+        )
+    store = Store(cache_path(repo))
+    try:
+        symbols = store.all_symbols()
+        edges = store.all_edges()
+        G = build_graph(symbols, edges)
+        matches = semantic_find(store, G, intent, top_k=top_k)
+    finally:
+        store.close()
+
+    if as_json:
+        click.echo(
+            json.dumps(
+                [
+                    {
+                        "qualified_name": m.symbol.get("qualified_name"),
+                        "kind": m.symbol.get("kind"),
+                        "path": m.symbol.get("path"),
+                        "score": round(m.score, 4),
+                        "community": m.community,
+                    }
+                    for m in matches
+                ],
+                indent=2,
+            )
+        )
+        return
+
+    if not matches:
+        click.echo("(no matches)")
+        return
+    for m in matches:
+        click.echo(
+            f"{m.score:7.3f}  c{m.community:<3}  {m.symbol.get('kind') or '':<10}  "
+            f"{m.symbol.get('qualified_name') or ''}  ({m.symbol.get('path') or ''})"
+        )
+
+
+__all__ = ["find_cmd"]

--- a/graphify_plus/interface/cli/prune_cmd.py
+++ b/graphify_plus/interface/cli/prune_cmd.py
@@ -1,0 +1,68 @@
+"""``gp prune`` — list dead-code, orphan, and (optionally) deprecated
+symbol ids that the budgeter should exclude from any framed context.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import click
+
+from ...core.symbol_graph import build as build_graph
+from ...query.prune import report as prune_report
+from ...runtime.store import Store, cache_path
+
+
+@click.command("prune")
+@click.option(
+    "--repo",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    default=Path("."),
+)
+@click.option(
+    "--aggressive",
+    is_flag=True,
+    help="Also include 'deprecated' symbols (docstring or path-based).",
+)
+@click.option("--json", "as_json", is_flag=True)
+def prune_cmd(repo: Path, aggressive: bool, as_json: bool) -> None:
+    """Print symbol ids the budgeter should exclude."""
+    repo = repo.resolve()
+    if not cache_path(repo).exists():
+        raise click.ClickException(
+            f"No cache at {cache_path(repo)}. Run 'graphify-plus init --repo {repo}' first."
+        )
+    store = Store(cache_path(repo))
+    try:
+        symbols = store.all_symbols()
+        edges = store.all_edges()
+        G = build_graph(symbols, edges)
+        rep = prune_report(G)
+    finally:
+        store.close()
+
+    if as_json:
+        click.echo(
+            json.dumps(
+                {
+                    "dead": sorted(rep.dead),
+                    "orphans": sorted(rep.orphans),
+                    "deprecated": sorted(rep.deprecated),
+                    "exclude": sorted(rep.all_ids(aggressive=aggressive)),
+                },
+                indent=2,
+            )
+        )
+        return
+
+    click.echo(f"dead       {len(rep.dead)}")
+    click.echo(f"orphans    {len(rep.orphans)}")
+    click.echo(f"deprecated {len(rep.deprecated)}")
+    excl = rep.all_ids(aggressive=aggressive)
+    click.echo(f"exclude    {len(excl)} (aggressive={aggressive})")
+    for sid in sorted(excl):
+        click.echo(f"  {sid}")
+
+
+__all__ = ["prune_cmd"]

--- a/graphify_plus/query/budget.py
+++ b/graphify_plus/query/budget.py
@@ -93,7 +93,11 @@ def _skeleton_for(store: Store, sid: str) -> tuple[str | None, str | None]:
 
 
 def frame_to_budget(
-    partition: Partition, store: Store, *, max_tokens: int = 4000
+    partition: Partition,
+    store: Store,
+    *,
+    max_tokens: int = 4000,
+    exclude: set[str] | None = None,
 ) -> BudgetedContext:
     """Pack ``partition`` into ``max_tokens`` of skeleton text.
 
@@ -106,15 +110,19 @@ def frame_to_budget(
     truncated_count = 0
     cut_count = 0
 
+    excl = exclude or set()
     # 1) Resolve symbols + skeletons in priority order.
     seen: set[str] = set()
     ordered_ids: list[tuple[str, str]] = []  # (sid, role)
 
     for sid in partition.gatekeepers:
-        if sid not in seen:
-            seen.add(sid)
-            ordered_ids.append((sid, "gatekeeper"))
+        if sid in excl or sid in seen:
+            continue
+        seen.add(sid)
+        ordered_ids.append((sid, "gatekeeper"))
     for sid in partition.path:
+        # Path nodes are NEVER excluded — the path is the contract with
+        # the caller. Pruning trims neighbours/extras only.
         if sid not in seen:
             seen.add(sid)
             ordered_ids.append((sid, "path"))
@@ -122,7 +130,7 @@ def frame_to_budget(
     # Sort neighbours by importance, then id for stability.
     neigh_ranked: list[tuple[Symbol, str]] = []
     for sid in partition.neighbours:
-        if sid in seen:
+        if sid in seen or sid in excl:
             continue
         node = partition.induced.nodes.get(sid)
         if node is None:

--- a/graphify_plus/query/prune.py
+++ b/graphify_plus/query/prune.py
@@ -1,0 +1,123 @@
+"""Ghost-Dependency / Dead-Code Pruning.
+
+Heuristics applied to the symbol graph:
+
+  - **Dead code**: leaf symbols (no out-edges of kind calls/references)
+    that also have no inbound calls/references/extends/implements.
+  - **Orphans**: symbols in a weakly-connected component of size 1.
+  - **Deprecated**: docstring contains "deprecated" (case-insensitive),
+    or path matches ``**/legacy/**`` / ``**/deprecated/**``.
+
+These are *recommendations*, not mutations. ``gp prune`` returns the IDs
+to ignore; the budgeter (Phase 3) consumes that set to exclude them
+from any framed context.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+import networkx as nx
+
+from ..core.adapters import Symbol
+
+DEPRECATED_RE = re.compile(r"\bdeprecated\b", re.IGNORECASE)
+LEGACY_PATH_RE = re.compile(r"(?:^|/)(?:legacy|deprecated)/", re.IGNORECASE)
+
+_INBOUND_KINDS = {"calls", "references", "extends", "implements"}
+_OUTBOUND_KINDS = {"calls", "references"}
+
+
+@dataclass(frozen=True)
+class PruneReport:
+    dead: set[str] = field(default_factory=set)
+    orphans: set[str] = field(default_factory=set)
+    deprecated: set[str] = field(default_factory=set)
+
+    def all_ids(self, *, aggressive: bool = False) -> set[str]:
+        out = set(self.dead) | set(self.orphans)
+        if aggressive:
+            out |= self.deprecated
+        return out
+
+
+def _has_inbound(G: nx.MultiDiGraph, sid: str) -> bool:
+    for _, _, data in G.in_edges(sid, data=True):
+        if (data or {}).get("kind") in _INBOUND_KINDS:
+            return True
+    return False
+
+
+def _has_outbound(G: nx.MultiDiGraph, sid: str) -> bool:
+    for _, _, data in G.out_edges(sid, data=True):
+        if (data or {}).get("kind") in _OUTBOUND_KINDS:
+            return True
+    return False
+
+
+def _is_protected(sym: Symbol) -> bool:
+    """Module-level synthetic symbols and exported APIs are never pruned."""
+    kind = sym.get("kind") or ""
+    if kind in {"module", "external", "endpoint"}:
+        return True
+    if sym.get("exported"):
+        return True
+    return False
+
+
+def find_dead_code(G: nx.MultiDiGraph) -> set[str]:
+    out: set[str] = set()
+    for sid, attrs in G.nodes(data=True):
+        if (attrs or {}).get("kind") == "external":
+            continue
+        sym: Symbol = dict(attrs)  # type: ignore[assignment]
+        if _is_protected(sym):
+            continue
+        if _has_inbound(G, sid):
+            continue
+        if _has_outbound(G, sid):
+            continue
+        out.add(sid)
+    return out
+
+
+def find_orphans(G: nx.MultiDiGraph) -> set[str]:
+    UG = G.to_undirected(as_view=False)
+    out: set[str] = set()
+    for comp in nx.connected_components(UG):
+        if len(comp) == 1:
+            (sid,) = comp
+            sym: Symbol = dict(G.nodes[sid])  # type: ignore[assignment]
+            if _is_protected(sym):
+                continue
+            out.add(sid)
+    return out
+
+
+def find_deprecated(G: nx.MultiDiGraph) -> set[str]:
+    out: set[str] = set()
+    for sid, attrs in G.nodes(data=True):
+        a = attrs or {}
+        doc = a.get("docstring") or ""
+        path = a.get("path") or ""
+        if DEPRECATED_RE.search(doc) or LEGACY_PATH_RE.search(path):
+            out.add(sid)
+    return out
+
+
+def report(G: nx.MultiDiGraph) -> PruneReport:
+    return PruneReport(
+        dead=find_dead_code(G),
+        orphans=find_orphans(G),
+        deprecated=find_deprecated(G),
+    )
+
+
+__all__ = [
+    "PruneReport",
+    "find_dead_code",
+    "find_deprecated",
+    "find_orphans",
+    "report",
+]

--- a/graphify_plus/query/semantic.py
+++ b/graphify_plus/query/semantic.py
@@ -1,0 +1,133 @@
+"""Semantic neighbourhood discovery.
+
+Given a natural-language intent ("where is pricing calculated?"), return
+the best-matching symbols.
+
+Two-stage routing:
+
+  1. **Louvain community detection** on the symbol graph (deterministic
+     with a fixed seed). Communities are cached in SQLite so repeated
+     queries don't re-run the algorithm.
+  2. **BM25** over each community's symbol qualified-names + docstrings,
+     scored as ``bm25_score × community_density_weight``.
+
+An optional ``--with-embeddings`` mode (Feature 6 step 4) augments BM25
+with sentence-transformers + per-community FAISS — only enabled when the
+``embeddings`` extra is installed. Phase 4 ships the pure-python BM25
+default; the embedding layer is a follow-up that can land any time after
+this without needing a fresh phase.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+
+import networkx as nx
+from rank_bm25 import BM25Okapi  # type: ignore[import-untyped]
+
+from ..core.adapters import Symbol
+from ..runtime.store import Store
+
+LOUVAIN_SEED = 1337
+TOKEN_RE = re.compile(r"[A-Za-z][A-Za-z0-9]*")
+
+
+def _tokenize(text: str) -> list[str]:
+    return [t.lower() for t in TOKEN_RE.findall(text or "")]
+
+
+def _doc_for(sym: Symbol) -> str:
+    parts = [
+        sym.get("qualified_name") or "",
+        sym.get("name") or "",
+        sym.get("signature") or "",
+        sym.get("docstring") or "",
+        sym.get("kind") or "",
+        sym.get("language") or "",
+    ]
+    return " ".join(p for p in parts if p)
+
+
+@dataclass
+class SymbolMatch:
+    symbol: Symbol
+    score: float
+    community: int
+
+
+def _undirected(G: nx.MultiDiGraph) -> nx.Graph:
+    UG = nx.Graph()
+    UG.add_nodes_from(G.nodes(data=True))
+    for u, v in G.edges():
+        if u != v and not UG.has_edge(u, v):
+            UG.add_edge(u, v)
+    return UG
+
+
+def communities(store: Store, G: nx.MultiDiGraph) -> dict[str, int]:
+    """Return ``{symbol_id: community_index}``. Cached in ``meta``."""
+    cached = store.get_meta("communities_v1")
+    if cached:
+        return json.loads(cached)
+    UG = _undirected(G)
+    if not UG.nodes:
+        return {}
+    parts = nx.community.louvain_communities(UG, seed=LOUVAIN_SEED)
+    parts_sorted = [sorted(p) for p in parts]
+    parts_sorted.sort(key=lambda p: (-len(p), p[0] if p else ""))
+    out: dict[str, int] = {}
+    for idx, part in enumerate(parts_sorted):
+        for sid in part:
+            out[sid] = idx
+    store.set_meta("communities_v1", json.dumps(out, sort_keys=True))
+    return out
+
+
+def find(store: Store, G: nx.MultiDiGraph, query: str, *, top_k: int = 8) -> list[SymbolMatch]:
+    """BM25 over per-community indices, weighted by community density."""
+    symbols = store.all_symbols()
+    if not symbols:
+        return []
+    comm = communities(store, G)
+    by_comm: dict[int, list[Symbol]] = {}
+    for s in symbols:
+        c = comm.get(s["id"], -1)
+        by_comm.setdefault(c, []).append(s)
+
+    # community density weight = log(1 + density) — prefer richer
+    # communities slightly when scores are otherwise tied.
+    UG = _undirected(G)
+    weights: dict[int, float] = {}
+    for c, members in by_comm.items():
+        sub = UG.subgraph([s["id"] for s in members])
+        if sub.number_of_nodes() <= 1:
+            weights[c] = 1.0
+            continue
+        n = sub.number_of_nodes()
+        m = sub.number_of_edges()
+        density = (2 * m) / (n * (n - 1)) if n > 1 else 0.0
+        from math import log1p
+
+        weights[c] = 1.0 + log1p(density)
+
+    q_tokens = _tokenize(query)
+    matches: list[SymbolMatch] = []
+    for c, members in by_comm.items():
+        if not members:
+            continue
+        corpus = [_tokenize(_doc_for(s)) for s in members]
+        if not any(corpus):
+            continue
+        bm25 = BM25Okapi(corpus)
+        scores = bm25.get_scores(q_tokens)
+        for s, score in zip(members, scores, strict=False):
+            if score <= 0:
+                continue
+            matches.append(SymbolMatch(symbol=s, score=float(score) * weights[c], community=c))
+    matches.sort(key=lambda m: (-m.score, m.symbol["qualified_name"]))
+    return matches[:top_k]
+
+
+__all__ = ["SymbolMatch", "communities", "find"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "xxhash>=3.4",
     "GitPython>=3.1",
     "tiktoken>=0.7",  # Phase 3 token-budgeted framing
+    "rank-bm25>=0.2",  # Phase 4 semantic finder (pure-python, no tokenizer deps)
 ]
 
 [project.optional-dependencies]

--- a/tests/query/test_prune.py
+++ b/tests/query/test_prune.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import networkx as nx
+
+from graphify_plus.query.prune import (
+    find_dead_code,
+    find_deprecated,
+    find_orphans,
+    report,
+)
+
+
+def _node(G, sid, **attrs):
+    G.add_node(sid, id=sid, **attrs)
+
+
+def test_dead_code_skips_protected():
+    G: nx.MultiDiGraph = nx.MultiDiGraph()
+    _node(G, "mod", kind="module", exported=True)
+    _node(G, "exp", kind="function", exported=True)
+    _node(G, "live", kind="function", exported=False)
+    _node(G, "dead", kind="function", exported=False)
+    G.add_edge("live", "exp", kind="calls")  # 'live' is alive, 'dead' is not
+    dead = find_dead_code(G)
+    assert "dead" in dead
+    assert "exp" not in dead
+    assert "mod" not in dead
+    assert "live" not in dead
+
+
+def test_orphans_singletons_only_unprotected():
+    G: nx.MultiDiGraph = nx.MultiDiGraph()
+    _node(G, "lonely", kind="function", exported=False)
+    _node(G, "module_alone", kind="module", exported=True)
+    _node(G, "a", kind="function", exported=False)
+    _node(G, "b", kind="function", exported=False)
+    G.add_edge("a", "b", kind="calls")
+    orphans = find_orphans(G)
+    assert "lonely" in orphans
+    assert "module_alone" not in orphans
+    assert "a" not in orphans
+
+
+def test_deprecated_via_docstring_or_path():
+    G: nx.MultiDiGraph = nx.MultiDiGraph()
+    _node(G, "doc_dep", kind="function", docstring="Deprecated. Use bar.")
+    _node(G, "path_dep", kind="function", path="src/legacy/foo.py", docstring="")
+    _node(G, "ok", kind="function", docstring="")
+    deps = find_deprecated(G)
+    assert "doc_dep" in deps
+    assert "path_dep" in deps
+    assert "ok" not in deps
+
+
+def test_report_aggregates():
+    G: nx.MultiDiGraph = nx.MultiDiGraph()
+    # Two connected nodes — neither is dead nor orphan, but one is
+    # deprecated. Aggressive=True is the only way to exclude it.
+    _node(G, "caller", kind="function", exported=True)
+    _node(G, "dep", kind="function", exported=True, docstring="DEPRECATED — old API.")
+    G.add_edge("caller", "dep", kind="calls")
+    rep = report(G)
+    assert "dep" in rep.deprecated
+    assert "dep" not in rep.dead
+    assert "dep" not in rep.orphans
+    assert "dep" not in rep.all_ids(aggressive=False)
+    assert "dep" in rep.all_ids(aggressive=True)

--- a/tests/query/test_semantic.py
+++ b/tests/query/test_semantic.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+from graphify_plus.core import cas
+from graphify_plus.core.ingest import ingest
+from graphify_plus.core.skeletonizer import skeletonize_all
+from graphify_plus.core.symbol_graph import build as build_graph
+from graphify_plus.query.semantic import communities, find
+from graphify_plus.runtime.store import Store, cache_path
+
+FIXTURE = Path(__file__).resolve().parents[1] / "fixtures" / "sample_repo"
+
+
+def _seed(tmp_path: Path) -> Path:
+    target = tmp_path / "repo"
+    shutil.copytree(FIXTURE, target)
+    res = ingest(target, parallel=False)
+    skel = skeletonize_all(res.symbols)
+    s = Store(cache_path(target))
+    try:
+        s.replace_all(res.symbols, res.edges)
+        for sid, body in skel.items():
+            h = cas.put(s, body)
+            s.link_skeleton(sid, h)
+    finally:
+        s.close()
+    return target
+
+
+def test_find_locates_invoice_total(tmp_path: Path):
+    repo = _seed(tmp_path)
+    s = Store(cache_path(repo))
+    try:
+        G = build_graph(s.all_symbols(), s.all_edges())
+        matches = find(s, G, "where is invoice total computed", top_k=5)
+    finally:
+        s.close()
+    assert matches, "expected at least one match"
+    qnames = [m.symbol["qualified_name"] for m in matches]
+    # Top match must be the relevant symbol.
+    assert qnames[0] == "invoice.Invoice.total"
+
+
+def test_communities_are_deterministic(tmp_path: Path):
+    repo = _seed(tmp_path)
+    s = Store(cache_path(repo))
+    try:
+        G = build_graph(s.all_symbols(), s.all_edges())
+        c1 = communities(s, G)
+        # Re-build to bypass meta cache: clear it then rebuild.
+        s.set_meta("communities_v1", "")
+        s.conn.execute("DELETE FROM meta WHERE key='communities_v1'")
+        c2 = communities(s, G)
+    finally:
+        s.close()
+    assert c1 == c2
+
+
+def test_no_matches_for_irrelevant_query(tmp_path: Path):
+    repo = _seed(tmp_path)
+    s = Store(cache_path(repo))
+    try:
+        G = build_graph(s.all_symbols(), s.all_edges())
+        # Term that doesn't appear in any symbol; BM25 returns score≤0,
+        # which find() filters out.
+        matches = find(s, G, "zxqvy nonexistent unicornium", top_k=5)
+    finally:
+        s.close()
+    assert matches == []


### PR DESCRIPTION
Phase 4 of EXECUTION_PLAN.md. Implements Features 6 + 8.

## Summary
- query/semantic.py — BM25 over Louvain-community-partitioned indices, deterministic and cached.
- query/prune.py — dead-code / orphan / deprecated detection (heuristic, opt-in).
- gp find --intent and gp prune CLIs.
- gp context grows --apply-prune / --aggressive-prune; budgeter excludes pruned ids from gatekeepers + neighbours (path nodes always preserved).
- pyproject.toml: rank-bm25 added as a base dep.

## Tests
136 passed (+7 new). Top-1 hit on 'where is invoice total computed' is invoice.Invoice.total. Communities are deterministic across re-runs.

## Out of scope
- Embeddings layer (rank-bm25 ships now; sentence-transformers + FAISS extra is documented as optional follow-up).
- Confidence-weighted pruning (RESILIENCE_PLAN Phase 11).