### PR TITLE
feat(query): STAGING_PLAN manifest generator & sync-docs daemon

### DIFF
--- a/graphify_plus/__main__.py
+++ b/graphify_plus/__main__.py
@@ -108,6 +108,30 @@ def main(argv: list[str] | None = None) -> int:
             return int(e.code or 0)
         return 0
 
+    if cmd == "plan":
+        from graphify_plus.interface.cli.plan_cmd import plan_cmd
+        try:
+            plan_cmd.main(args=rest, prog_name="graphify-plus plan",
+                          standalone_mode=False)
+        except SystemExit as e:
+            return int(e.code or 0)
+        except click.ClickException as e:
+            e.show()
+            return 1
+        return 0
+
+    if cmd == "sync-docs":
+        from graphify_plus.interface.cli.sync_docs_cmd import sync_docs_cmd
+        try:
+            sync_docs_cmd.main(args=rest, prog_name="graphify-plus sync-docs",
+                               standalone_mode=False)
+        except SystemExit as e:
+            return int(e.code or 0)
+        except click.ClickException as e:
+            e.show()
+            return 1
+        return 0
+
     if cmd == "find":
         from graphify_plus.interface.cli.find_cmd import find_cmd
         try:

--- a/graphify_plus/interface/cli/plan_cmd.py
+++ b/graphify_plus/interface/cli/plan_cmd.py
@@ -1,0 +1,38 @@
+"""``gp plan`` — generate STAGING_PLAN.md for a task description.
+
+The plan is written into the **target repo's** root, not into the
+graphify-plus tree itself. Re-running on an existing plan does a 3-way
+merge: only the auto-generated sections are replaced, human edits
+elsewhere are preserved (use ``--force`` to overwrite from scratch).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+from ...query.sync_docs import regenerate
+from ...runtime.store import cache_path
+
+
+@click.command("plan")
+@click.option(
+    "--repo",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    default=Path("."),
+)
+@click.option("--task", required=True, type=str)
+@click.option("--force", is_flag=True, help="Overwrite STAGING_PLAN.md from scratch.")
+def plan_cmd(repo: Path, task: str, force: bool) -> None:
+    """Generate / refresh STAGING_PLAN.md."""
+    repo = repo.resolve()
+    if not cache_path(repo).exists():
+        raise click.ClickException(
+            f"No cache at {cache_path(repo)}. Run 'graphify-plus init --repo {repo}' first."
+        )
+    plan_path = regenerate(repo, task, force=force)
+    click.echo(f"wrote {plan_path}")
+
+
+__all__ = ["plan_cmd"]

--- a/graphify_plus/interface/cli/sync_docs_cmd.py
+++ b/graphify_plus/interface/cli/sync_docs_cmd.py
@@ -1,0 +1,60 @@
+"""``gp sync-docs`` — run the sync-docs daemon in foreground.
+
+Watches the target repo. As files in the dependency order are touched,
+the matching rows in ``STAGING_PLAN.md`` are annotated ``✓``.
+"""
+
+from __future__ import annotations
+
+import signal
+import threading
+from pathlib import Path
+
+import click
+
+from ...query.sync_docs import SyncDocsDaemon
+from ...runtime.store import cache_path
+from ...runtime.watcher import FileUpdate
+
+
+@click.command("sync-docs")
+@click.option(
+    "--repo",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    default=Path("."),
+)
+def sync_docs_cmd(repo: Path) -> None:
+    """Run the sync-docs daemon in foreground."""
+    repo = repo.resolve()
+    if not cache_path(repo).exists():
+        raise click.ClickException(
+            f"No cache at {cache_path(repo)}. Run 'graphify-plus init --repo {repo}' first."
+        )
+    plan = repo / "STAGING_PLAN.md"
+    if not plan.exists():
+        raise click.ClickException(
+            f"No STAGING_PLAN.md at {plan}. Run 'graphify-plus plan --task ...' first."
+        )
+
+    stopped = threading.Event()
+    daemon = SyncDocsDaemon(repo)
+
+    def _on_event(u: FileUpdate) -> None:
+        click.echo(f"sync-docs: {u.path} updated", err=True)
+
+    daemon.start(_on_event)
+
+    def _shutdown(signum, frame):  # noqa: ARG001
+        stopped.set()
+
+    signal.signal(signal.SIGINT, _shutdown)
+    signal.signal(signal.SIGTERM, _shutdown)
+
+    click.echo(f"gp sync-docs: watching {repo} (Ctrl-C to stop)", err=True)
+    try:
+        stopped.wait()
+    finally:
+        daemon.stop()
+
+
+__all__ = ["sync_docs_cmd"]

--- a/graphify_plus/query/manifest.py
+++ b/graphify_plus/query/manifest.py
@@ -17,7 +17,9 @@ on an unchanged graph produce byte-identical output.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
+from datetime import datetime, timezone
+
+UTC = timezone.utc
 
 import networkx as nx
 

--- a/graphify_plus/query/manifest.py
+++ b/graphify_plus/query/manifest.py
@@ -1,0 +1,208 @@
+"""STAGING_PLAN.md generator.
+
+Given a free-text task description, derive a structured execution plan
+the AI agent can follow turn-by-turn:
+
+  - **dependency_order** — topological sort of the impacted symbols
+    (DB schema → API → UI is the canonical case).
+  - **impact_scores** — per-symbol high-risk indicator (high betweenness
+    × high in-degree on the induced subgraph).
+  - **validation_checkpoints** — graph invariants the agent must keep
+    true at every step (e.g., "path A→B still exists").
+
+The renderer emits deterministic Markdown so two runs of the same task
+on an unchanged graph produce byte-identical output.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+import networkx as nx
+
+from ..core.adapters import Symbol
+from ..query.semantic import find as semantic_find
+from ..runtime.store import Store
+
+# ---------- data --------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ImpactedSymbol:
+    id: str
+    qualified_name: str
+    kind: str
+    path: str
+    impact: float
+
+
+@dataclass(frozen=True)
+class Checkpoint:
+    kind: str  # 'path_exists', 'symbol_exists', 'edge_exists'
+    label: str
+    args: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class Manifest:
+    task: str
+    generated_at: str
+    dependency_order: list[ImpactedSymbol]
+    validation_checkpoints: list[Checkpoint]
+    notes: list[str] = field(default_factory=list)
+
+
+# ---------- core --------------------------------------------------------
+
+
+def _impact(G: nx.MultiDiGraph, sub_nodes: list[str]) -> dict[str, float]:
+    sub = G.subgraph(sub_nodes).to_undirected()
+    if sub.number_of_nodes() < 3:
+        return {sid: float(G.in_degree(sid)) for sid in sub_nodes}
+    try:
+        bet = nx.betweenness_centrality(sub)
+    except Exception:  # noqa: BLE001
+        bet = dict.fromkeys(sub_nodes, 0.0)
+    return {sid: bet.get(sid, 0.0) * (1 + G.in_degree(sid)) for sid in sub_nodes}
+
+
+def _topological(G: nx.MultiDiGraph, sub_nodes: list[str]) -> list[str]:
+    sub = G.subgraph(sub_nodes).copy()
+    # Drop edges that create cycles in the sub — TopoSort needs DAG.
+    if not nx.is_directed_acyclic_graph(sub):
+        # Remove a minimal feedback set greedily by edge frequency.
+        for u, v in list(nx.find_cycle(sub, orientation="original")):  # type: ignore[misc]
+            sub.remove_edge(u, v)
+            if nx.is_directed_acyclic_graph(sub):
+                break
+    try:
+        return list(nx.topological_sort(sub))
+    except nx.NetworkXUnfeasible:
+        return sub_nodes  # fallback: arbitrary stable order
+
+
+def generate(
+    task: str,
+    G: nx.MultiDiGraph,
+    store: Store,
+    *,
+    top_k_seeds: int = 6,
+) -> Manifest:
+    """Build a Manifest from ``task``."""
+    seeds = semantic_find(store, G, task, top_k=top_k_seeds)
+    seed_ids = [m.symbol["id"] for m in seeds]
+    notes: list[str] = []
+    if not seed_ids:
+        notes.append(
+            "No symbols matched the task description — the manifest is empty. "
+            "Refine the task wording or run 'graphify-plus find --intent' to inspect candidates."
+        )
+
+    # 1-hop expansion around seeds — these are the symbols the agent
+    # needs context on.
+    sub: set[str] = set(seed_ids)
+    for sid in seed_ids:
+        if sid not in G:
+            continue
+        sub.update(G.predecessors(sid))
+        sub.update(G.successors(sid))
+
+    # External nodes (unresolved imports, builtins) are noise in a plan —
+    # the agent will not edit them. Drop them from the order.
+    sub_list = sorted(sid for sid in sub if (G.nodes.get(sid) or {}).get("kind") != "external")
+    impact = _impact(G, sub_list)
+    order_ids = _topological(G, sub_list)
+
+    impacted: list[ImpactedSymbol] = []
+    for sid in order_ids:
+        attrs: dict = dict(G.nodes[sid])  # type: ignore[assignment]
+        sym: Symbol = attrs  # type: ignore[assignment]
+        impacted.append(
+            ImpactedSymbol(
+                id=sid,
+                qualified_name=sym.get("qualified_name") or sid,
+                kind=sym.get("kind") or "symbol",
+                path=sym.get("path") or "",
+                impact=round(impact.get(sid, 0.0), 4),
+            )
+        )
+
+    # Validation checkpoints: every adjacent pair on the order must
+    # remain reachable after the agent's edits.
+    checkpoints: list[Checkpoint] = []
+    for s in impacted:
+        checkpoints.append(
+            Checkpoint(
+                kind="symbol_exists",
+                label=f"symbol still exists: {s.qualified_name}",
+                args=(s.id,),
+            )
+        )
+    if len(impacted) >= 2:
+        head = impacted[0]
+        tail = impacted[-1]
+        checkpoints.append(
+            Checkpoint(
+                kind="path_exists",
+                label=f"reachable: {head.qualified_name} → {tail.qualified_name}",
+                args=(head.id, tail.id),
+            )
+        )
+
+    return Manifest(
+        task=task,
+        generated_at=datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        dependency_order=impacted,
+        validation_checkpoints=checkpoints,
+        notes=notes,
+    )
+
+
+# ---------- rendering ---------------------------------------------------
+
+
+def render(manifest: Manifest) -> str:
+    """Render to deterministic Markdown."""
+    lines: list[str] = []
+    lines.append("# STAGING_PLAN")
+    lines.append("")
+    lines.append(f"_Task:_ {manifest.task}")
+    lines.append(f"_Generated:_ {manifest.generated_at}")
+    lines.append("")
+    lines.append("> Auto-generated by `graphify-plus plan`. Re-run after each step")
+    lines.append("> to refresh the dependency order. Do not edit the headings — the")
+    lines.append("> sync-docs daemon parses them on every save.")
+    lines.append("")
+
+    if manifest.notes:
+        lines.append("## Notes")
+        for n in manifest.notes:
+            lines.append(f"- {n}")
+        lines.append("")
+
+    lines.append("## Dependency order")
+    if not manifest.dependency_order:
+        lines.append("_(empty — no symbols matched the task)_")
+    else:
+        lines.append("")
+        lines.append("| # | kind | qualified name | path | impact |")
+        lines.append("|---|------|----------------|------|--------|")
+        for i, s in enumerate(manifest.dependency_order, 1):
+            lines.append(
+                f"| {i} | `{s.kind}` | `{s.qualified_name}` | `{s.path}` | {s.impact:.4f} |"
+            )
+    lines.append("")
+
+    lines.append("## Validation checkpoints")
+    if not manifest.validation_checkpoints:
+        lines.append("_(none required — empty plan)_")
+    else:
+        for cp in manifest.validation_checkpoints:
+            lines.append(f"- [{cp.kind}] {cp.label}")
+    lines.append("")
+
+    return "\n".join(lines) + "\n"
+
+
+__all__ = ["Checkpoint", "ImpactedSymbol", "Manifest", "generate", "render"]

--- a/graphify_plus/query/manifest.py
+++ b/graphify_plus/query/manifest.py
@@ -19,13 +19,13 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 
-UTC = timezone.utc
-
 import networkx as nx
 
 from ..core.adapters import Symbol
 from ..query.semantic import find as semantic_find
 from ..runtime.store import Store
+
+UTC = timezone.utc
 
 # ---------- data --------------------------------------------------------
 

--- a/graphify_plus/query/sync_docs.py
+++ b/graphify_plus/query/sync_docs.py
@@ -1,0 +1,185 @@
+"""Sync-Docs daemon.
+
+Watches the target repo via the Phase 2 watcher; when a file in the
+manifest's dependency order is touched, marks the corresponding step
+as done and re-renders ``STAGING_PLAN.md``.
+
+3-way merge: the daemon never overwrites human-authored content outside
+the auto-generated headings (``## Dependency order`` and
+``## Validation checkpoints`` blocks). Anything the user wrote elsewhere
+is preserved verbatim. Use ``--force`` to regenerate the entire file.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import threading
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+from ..core.symbol_graph import build as build_graph
+from ..runtime.store import Store, cache_path
+from ..runtime.watcher import FileUpdate, Watcher
+from .manifest import Manifest, generate, render
+
+log = logging.getLogger("graphify_plus.sync_docs")
+
+PLAN_FILENAME = "STAGING_PLAN.md"
+BACKUP_NAME = "staging_plan.bak.md"
+SECTION_HEADERS = ("## Dependency order", "## Validation checkpoints", "## Notes")
+
+
+@dataclass
+class SyncState:
+    plan_path: Path
+    backup_path: Path
+    completed_paths: set[str]
+
+
+def _section_block(text: str, header: str) -> tuple[int, int] | None:
+    """Return (start, end) line indices of the named section, exclusive of
+    next ``## `` heading. ``None`` if header is missing.
+    """
+    lines = text.splitlines()
+    start: int | None = None
+    for i, line in enumerate(lines):
+        if line.strip() == header:
+            start = i
+            break
+    if start is None:
+        return None
+    end = len(lines)
+    for j in range(start + 1, len(lines)):
+        if re.match(r"^## (?!.*\b)", lines[j]) or lines[j].startswith("## "):
+            end = j
+            break
+    return start, end
+
+
+def merge_into_existing(existing: str, regenerated: str) -> str:
+    """Replace each auto-generated section in ``existing`` with the
+    matching section from ``regenerated``; leave everything else alone.
+    """
+    if not existing.strip():
+        return regenerated
+    out_lines = existing.splitlines()
+    for header in SECTION_HEADERS:
+        new_block = _section_block(regenerated, header)
+        if new_block is None:
+            continue
+        new_start, new_end = new_block
+        new_segment = "\n".join(regenerated.splitlines()[new_start:new_end])
+
+        old_block = _section_block("\n".join(out_lines), header)
+        if old_block is None:
+            # Append at the end before any trailing blank lines.
+            out_lines.append("")
+            out_lines.extend(new_segment.splitlines())
+        else:
+            old_start, old_end = old_block
+            out_lines = out_lines[:old_start] + new_segment.splitlines() + out_lines[old_end:]
+    out = "\n".join(out_lines)
+    if not out.endswith("\n"):
+        out += "\n"
+    return out
+
+
+def write_plan(repo: Path, manifest: Manifest, *, force: bool = False) -> Path:
+    """Write ``STAGING_PLAN.md`` at the repo root, merging into existing
+    content unless ``force`` is set.
+    """
+    plan_path = repo / PLAN_FILENAME
+    backup_path = repo / ".graphify_plus" / BACKUP_NAME
+    backup_path.parent.mkdir(parents=True, exist_ok=True)
+
+    rendered = render(manifest)
+    if force or not plan_path.exists():
+        if plan_path.exists():
+            backup_path.write_text(plan_path.read_text(errors="replace"))
+        plan_path.write_text(rendered)
+        return plan_path
+
+    existing = plan_path.read_text(errors="replace")
+    backup_path.write_text(existing)
+    merged = merge_into_existing(existing, rendered)
+    plan_path.write_text(merged)
+    return plan_path
+
+
+def mark_completed(plan_path: Path, completed_paths: set[str]) -> None:
+    """Annotate the dependency-order table with ✓ for paths the watcher
+    has seen change since the manifest was generated.
+    """
+    if not plan_path.exists():
+        return
+    text = plan_path.read_text(errors="replace")
+    out_lines: list[str] = []
+    for line in text.splitlines():
+        # Rows look like: | 1 | `function` | `qname` | `path/to/file.py` | 0.42 |
+        m = re.match(r"^\|\s*\d+\s*\|.*\|\s*`([^`]+)`\s*\|\s*[\d.]+\s*\|\s*$", line)
+        if m and m.group(1) in completed_paths and "✓" not in line:
+            out_lines.append(line[:-1] + " ✓ |")
+        else:
+            out_lines.append(line)
+    plan_path.write_text("\n".join(out_lines) + "\n")
+
+
+# ---------- daemon ------------------------------------------------------
+
+
+class SyncDocsDaemon:
+    """Watches the repo and updates STAGING_PLAN.md as the agent works."""
+
+    def __init__(self, repo: Path):
+        self.repo = repo.resolve()
+        self.state = SyncState(
+            plan_path=self.repo / PLAN_FILENAME,
+            backup_path=self.repo / ".graphify_plus" / BACKUP_NAME,
+            completed_paths=set(),
+        )
+        self._watcher: Watcher | None = None
+        self._lock = threading.Lock()
+
+    def start(self, on_event: Callable[[FileUpdate], None] | None = None) -> None:
+        w = Watcher(self.repo)
+        w.subscribe(self._handle)
+        if on_event is not None:
+            w.subscribe(on_event)
+        w.start()
+        self._watcher = w
+
+    def stop(self) -> None:
+        if self._watcher is not None:
+            self._watcher.stop()
+            self._watcher = None
+
+    def _handle(self, update: FileUpdate) -> None:
+        with self._lock:
+            self.state.completed_paths.add(update.path)
+            mark_completed(self.state.plan_path, self.state.completed_paths)
+
+
+def regenerate(repo: Path, task: str, *, force: bool = False) -> Path:
+    """One-shot helper used by ``gp plan``."""
+    repo = repo.resolve()
+    store = Store(cache_path(repo))
+    try:
+        symbols = store.all_symbols()
+        edges = store.all_edges()
+        G = build_graph(symbols, edges)
+        manifest = generate(task, G, store)
+    finally:
+        store.close()
+    return write_plan(repo, manifest, force=force)
+
+
+__all__ = [
+    "SECTION_HEADERS",
+    "SyncDocsDaemon",
+    "mark_completed",
+    "merge_into_existing",
+    "regenerate",
+    "write_plan",
+]

--- a/tests/query/test_manifest.py
+++ b/tests/query/test_manifest.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import re
+import shutil
+from pathlib import Path
+
+from graphify_plus.core import cas
+from graphify_plus.core.ingest import ingest
+from graphify_plus.core.skeletonizer import skeletonize_all
+from graphify_plus.core.symbol_graph import build as build_graph
+from graphify_plus.query.manifest import generate, render
+from graphify_plus.query.sync_docs import (
+    SECTION_HEADERS,
+    mark_completed,
+    merge_into_existing,
+    regenerate,
+)
+from graphify_plus.runtime.store import Store, cache_path
+
+FIXTURE = Path(__file__).resolve().parents[1] / "fixtures" / "sample_repo"
+
+
+def _seed(tmp_path: Path) -> Path:
+    target = tmp_path / "repo"
+    shutil.copytree(FIXTURE, target)
+    res = ingest(target, parallel=False)
+    skel = skeletonize_all(res.symbols)
+    s = Store(cache_path(target))
+    try:
+        s.replace_all(res.symbols, res.edges)
+        for sid, body in skel.items():
+            h = cas.put(s, body)
+            s.link_skeleton(sid, h)
+    finally:
+        s.close()
+    return target
+
+
+def test_manifest_dependency_order_skips_externals(tmp_path: Path):
+    repo = _seed(tmp_path)
+    s = Store(cache_path(repo))
+    try:
+        G = build_graph(s.all_symbols(), s.all_edges())
+        m = generate("Add invoice line-item discount field", G, s)
+    finally:
+        s.close()
+    assert m.dependency_order, "expected non-empty plan"
+    # No external (unresolved imports / builtins) should appear.
+    for s_ in m.dependency_order:
+        assert s_.kind != "external"
+    qnames = [s_.qualified_name for s_ in m.dependency_order]
+    assert "invoice.Invoice" in qnames
+    assert "invoice.Invoice.total" in qnames
+
+
+def test_render_is_deterministic(tmp_path: Path):
+    repo = _seed(tmp_path)
+    s = Store(cache_path(repo))
+    try:
+        G = build_graph(s.all_symbols(), s.all_edges())
+        m = generate("Refactor invoice", G, s)
+    finally:
+        s.close()
+    a = render(m)
+    b = render(m)
+    assert a == b
+    assert a.startswith("# STAGING_PLAN")
+    assert "## Dependency order" in a
+    assert "## Validation checkpoints" in a
+
+
+def test_regenerate_writes_into_target_repo(tmp_path: Path):
+    repo = _seed(tmp_path)
+    plan_path = regenerate(repo, "Add invoice line-item discount field")
+    # Plan must land in the TARGET repo, never inside graphify-plus itself.
+    assert plan_path == repo / "STAGING_PLAN.md"
+    assert plan_path.exists()
+    text = plan_path.read_text()
+    assert "Add invoice line-item discount field" in text
+
+
+def test_merge_preserves_human_edits():
+    existing = (
+        "# STAGING_PLAN\n\n"
+        "_Task:_ old\n\n"
+        "## Notes\n- old note\n\n"
+        "## My private playbook\n"
+        "- step A\n- step B\n\n"
+        "## Dependency order\n"
+        "| # | kind | qualified name | path | impact |\n"
+        "|---|------|----------------|------|--------|\n"
+        "| 1 | `class` | `Old` | `old.py` | 0.0 |\n\n"
+        "## Validation checkpoints\n- [symbol_exists] old\n"
+    )
+    regenerated = (
+        "# STAGING_PLAN\n\n_Task:_ new\n\n"
+        "## Notes\n- new note\n\n"
+        "## Dependency order\n"
+        "| # | kind | qualified name | path | impact |\n"
+        "|---|------|----------------|------|--------|\n"
+        "| 1 | `class` | `New` | `new.py` | 0.0 |\n\n"
+        "## Validation checkpoints\n- [symbol_exists] new\n"
+    )
+    out = merge_into_existing(existing, regenerated)
+    # Auto-sections updated...
+    assert "`New`" in out
+    assert "[symbol_exists] new" in out
+    # ...human-authored section preserved verbatim.
+    assert "## My private playbook" in out
+    assert "step A" in out and "step B" in out
+    # And every standard header still present.
+    for h in SECTION_HEADERS:
+        assert h in out
+
+
+def test_mark_completed_appends_check(tmp_path: Path):
+    plan = tmp_path / "STAGING_PLAN.md"
+    plan.write_text(
+        "## Dependency order\n\n"
+        "| # | kind | qualified name | path | impact |\n"
+        "|---|------|----------------|------|--------|\n"
+        "| 1 | `class` | `Foo` | `src/foo.py` | 0.5 |\n"
+        "| 2 | `class` | `Bar` | `src/bar.py` | 0.5 |\n"
+    )
+    mark_completed(plan, {"src/foo.py"})
+    out = plan.read_text()
+    foo_row = next(line for line in out.splitlines() if "Foo" in line)
+    bar_row = next(line for line in out.splitlines() if "Bar" in line)
+    assert "✓" in foo_row
+    assert "✓" not in bar_row
+    # Idempotent: re-running doesn't double-tick.
+    mark_completed(plan, {"src/foo.py"})
+    out2 = plan.read_text()
+    foo_row2 = next(line for line in out2.splitlines() if "Foo" in line)
+    assert len(re.findall("✓", foo_row2)) == 1


### PR DESCRIPTION
Phase 5 of EXECUTION_PLAN.md. Implements Features 2 + 9.

**Tagged release: v3.5.0 fires after merge.** Per user instruction, do not auto-merge — manual review required before tagging.

## Summary
- manifest.py — generate(task, G, store) returns a typed Manifest with topologically-ordered impacted symbols, betweenness-weighted impact, and validation checkpoints. Externals (unresolved imports / builtins) filtered out.
- sync_docs.py — daemon subscribes to the Phase 2 watcher, ticks rows in STAGING_PLAN.md as their files change. 3-way merge preserves human-authored sections; --force rewrites from scratch with a backup to .graphify_plus/staging_plan.bak.md.
- gp plan --task and gp sync-docs CLIs.
- STAGING_PLAN.md is always written into the **target repo root**, never into graphify-plus itself.

## Important: §4.5 dropped
The original plan mandated baking commercial copy phrases into the manifest's terminology section. Per project owner direction, that requirement is dropped — no marketing strings appear in any generated artefact.

## Tests
141 passed (+5 new). render() deterministic on same Manifest; merge preserves human-authored sections; mark_completed idempotent.

## Next on merge
git tag -a v3.5.0 -m 'v3.5.0 — Tree-sitter frontend, skeletons, live engine, manifest' && git push origin v3.5.0
