### PR TITLE
feat(query,interface): git/telemetry/vuln/lockfile enrichment + privacy filter

### DIFF
--- a/graphify_plus/__init__.py
+++ b/graphify_plus/__init__.py
@@ -15,6 +15,7 @@ Other modules referenced in the README (temporal, reconcile, causal, contradict,
 budget, writeback, report_json, counterfactual, verification, selfhealing,
 multimodal, live, federation, local, personal) are planned but not yet shipped.
 """
+
 from __future__ import annotations
 
 __version__ = "3.1.1"

--- a/graphify_plus/__main__.py
+++ b/graphify_plus/__main__.py
@@ -11,6 +11,7 @@ Examples:
   graphify-plus audit path/to/graph.json --json
   graphify-plus diff old/graph.json new/graph.json --format markdown
 """
+
 from __future__ import annotations
 
 import argparse
@@ -24,6 +25,7 @@ import click
 def _load_graph(path: Path):
     """Load a graphify graph.json into a networkx.Graph."""
     import networkx as nx
+
     with open(path) as f:
         data = json.load(f)
     G = nx.Graph()
@@ -42,8 +44,12 @@ def _load_graph(path: Path):
 def _run_audit(rest: list[str]) -> int:
     parser = argparse.ArgumentParser(prog="graphify-plus audit")
     parser.add_argument("graph", help="Path to graphify graph.json")
-    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON instead of text")
-    parser.add_argument("--output", "-o", metavar="PATH", help="Write result to file instead of stdout")
+    parser.add_argument(
+        "--json", action="store_true", help="Emit machine-readable JSON instead of text"
+    )
+    parser.add_argument(
+        "--output", "-o", metavar="PATH", help="Write result to file instead of stdout"
+    )
     parser.add_argument(
         "--fail-below",
         choices=["A", "B", "C", "D", "F"],
@@ -92,20 +98,40 @@ def main(argv: list[str] | None = None) -> int:
 
     if cmd == "audit":
         from graphify_plus.audit.cli import main as audit_main
+
         return audit_main(rest)
 
     if cmd == "diff":
         from graphify_plus.review.cli import main as diff_main
+
         return diff_main(rest)
 
     if cmd == "init":
         from graphify_plus.interface.cli.init_cmd import init_cmd
+
         # Click commands are callable: standalone_mode=False bubbles errors
         try:
-            init_cmd.main(args=rest, prog_name="graphify-plus init",
-                          standalone_mode=False)
+            init_cmd.main(args=rest, prog_name="graphify-plus init", standalone_mode=False)
         except SystemExit as e:
             return int(e.code or 0)
+        return 0
+
+    if cmd in ("enrich", "blast-radius"):
+        from graphify_plus.interface.cli.enrich_cmd import (
+            blast_cmd,
+            enrich_cmd,
+        )
+
+        click_cmd_map = {"enrich": enrich_cmd, "blast-radius": blast_cmd}
+        try:
+            click_cmd_map[cmd].main(
+                args=rest, prog_name=f"graphify-plus {cmd}", standalone_mode=False
+            )
+        except SystemExit as e:
+            return int(e.code or 0)
+        except click.ClickException as e:
+            e.show()
+            return 1
         return 0
 
     if cmd in ("stitch", "coordinate"):
@@ -113,10 +139,12 @@ def main(argv: list[str] | None = None) -> int:
             coordinate_cmd,
             stitch_cmd,
         )
+
         click_cmd_map = {"stitch": stitch_cmd, "coordinate": coordinate_cmd}
         try:
-            click_cmd_map[cmd].main(args=rest, prog_name=f"graphify-plus {cmd}",
-                                     standalone_mode=False)
+            click_cmd_map[cmd].main(
+                args=rest, prog_name=f"graphify-plus {cmd}", standalone_mode=False
+            )
         except SystemExit as e:
             return int(e.code or 0)
         except click.ClickException as e:
@@ -130,11 +158,12 @@ def main(argv: list[str] | None = None) -> int:
             guardrails_cmd,
             simulate_cmd,
         )
-        click_cmd = {"simulate": simulate_cmd, "guardrails": guardrails_cmd,
-                     "drift": drift_cmd}[cmd]
+
+        click_cmd = {"simulate": simulate_cmd, "guardrails": guardrails_cmd, "drift": drift_cmd}[
+            cmd
+        ]
         try:
-            click_cmd.main(args=rest, prog_name=f"graphify-plus {cmd}",
-                           standalone_mode=False)
+            click_cmd.main(args=rest, prog_name=f"graphify-plus {cmd}", standalone_mode=False)
         except SystemExit as e:
             return int(e.code or 0)
         except click.ClickException as e:
@@ -144,9 +173,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if cmd == "plan":
         from graphify_plus.interface.cli.plan_cmd import plan_cmd
+
         try:
-            plan_cmd.main(args=rest, prog_name="graphify-plus plan",
-                          standalone_mode=False)
+            plan_cmd.main(args=rest, prog_name="graphify-plus plan", standalone_mode=False)
         except SystemExit as e:
             return int(e.code or 0)
         except click.ClickException as e:
@@ -156,9 +185,11 @@ def main(argv: list[str] | None = None) -> int:
 
     if cmd == "sync-docs":
         from graphify_plus.interface.cli.sync_docs_cmd import sync_docs_cmd
+
         try:
-            sync_docs_cmd.main(args=rest, prog_name="graphify-plus sync-docs",
-                               standalone_mode=False)
+            sync_docs_cmd.main(
+                args=rest, prog_name="graphify-plus sync-docs", standalone_mode=False
+            )
         except SystemExit as e:
             return int(e.code or 0)
         except click.ClickException as e:
@@ -168,9 +199,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if cmd == "find":
         from graphify_plus.interface.cli.find_cmd import find_cmd
+
         try:
-            find_cmd.main(args=rest, prog_name="graphify-plus find",
-                          standalone_mode=False)
+            find_cmd.main(args=rest, prog_name="graphify-plus find", standalone_mode=False)
         except SystemExit as e:
             return int(e.code or 0)
         except click.ClickException as e:
@@ -180,9 +211,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if cmd == "prune":
         from graphify_plus.interface.cli.prune_cmd import prune_cmd
+
         try:
-            prune_cmd.main(args=rest, prog_name="graphify-plus prune",
-                           standalone_mode=False)
+            prune_cmd.main(args=rest, prog_name="graphify-plus prune", standalone_mode=False)
         except SystemExit as e:
             return int(e.code or 0)
         except click.ClickException as e:
@@ -192,9 +223,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if cmd == "context":
         from graphify_plus.interface.cli.context_cmd import context_cmd
+
         try:
-            context_cmd.main(args=rest, prog_name="graphify-plus context",
-                             standalone_mode=False)
+            context_cmd.main(args=rest, prog_name="graphify-plus context", standalone_mode=False)
         except SystemExit as e:
             return int(e.code or 0)
         except click.ClickException as e:
@@ -204,9 +235,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if cmd == "watch":
         from graphify_plus.interface.cli.watch_cmd import watch_cmd
+
         try:
-            watch_cmd.main(args=rest, prog_name="graphify-plus watch",
-                           standalone_mode=False)
+            watch_cmd.main(args=rest, prog_name="graphify-plus watch", standalone_mode=False)
         except SystemExit as e:
             return int(e.code or 0)
         except click.ClickException as e:
@@ -216,9 +247,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if cmd == "session":
         from graphify_plus.interface.cli.session_cmd import session_cmd
+
         try:
-            session_cmd.main(args=rest, prog_name="graphify-plus session",
-                             standalone_mode=False)
+            session_cmd.main(args=rest, prog_name="graphify-plus session", standalone_mode=False)
         except SystemExit as e:
             return int(e.code or 0)
         except click.ClickException as e:
@@ -228,9 +259,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if cmd == "skeleton":
         from graphify_plus.interface.cli.skeleton_cmd import skeleton_cmd
+
         try:
-            skeleton_cmd.main(args=rest, prog_name="graphify-plus skeleton",
-                              standalone_mode=False)
+            skeleton_cmd.main(args=rest, prog_name="graphify-plus skeleton", standalone_mode=False)
         except SystemExit as e:
             return int(e.code or 0)
         except click.ClickException as e:

--- a/graphify_plus/audit/__init__.py
+++ b/graphify_plus/audit/__init__.py
@@ -1,4 +1,5 @@
 """graphify_plus.audit — adversarial probes that grade graph quality."""
+
 from graphify_plus.audit.cli import main as cli_main  # noqa: F401
 from graphify_plus.audit.probe import (  # noqa: F401
     audit_meets_threshold,

--- a/graphify_plus/audit/cli.py
+++ b/graphify_plus/audit/cli.py
@@ -7,6 +7,7 @@ Usage:
     graphify-plus audit path/to/graph.json --only confidence_drift
     graphify-plus audit path/to/graph.json --fail-below B --quiet
 """
+
 from __future__ import annotations
 
 import argparse
@@ -80,7 +81,7 @@ def main(argv: list[str] | None = None) -> int:
         action="append",
         default=None,
         help="Run only the named probe(s). Repeat for multiple. "
-             "When set, output JSON contains only those probes.",
+        "When set, output JSON contains only those probes.",
     )
     parser.add_argument("--quiet", action="store_true", help="Suppress text report on stdout")
 

--- a/graphify_plus/audit/probe.py
+++ b/graphify_plus/audit/probe.py
@@ -25,7 +25,12 @@ import networkx as nx
 GradeStr = str  # "A" | "B" | "C" | "D" | "F" | "N/A"
 
 _GRADE_TO_NUMERIC: dict[GradeStr, int] = {
-    "A": 4, "B": 3, "C": 2, "D": 1, "F": 0, "N/A": -1,
+    "A": 4,
+    "B": 3,
+    "C": 2,
+    "D": 1,
+    "F": 0,
+    "N/A": -1,
 }
 
 _DEFAULT_TOP_K = 15
@@ -35,6 +40,7 @@ _DEFAULT_SAMPLE_SEED = 42
 # ---------------------------------------------------------------------------
 # Validation helpers
 # ---------------------------------------------------------------------------
+
 
 def _validate_graph(G: Any) -> tuple[bool, str]:
     """Return (ok, reason). Every probe calls this first."""
@@ -73,6 +79,7 @@ def _grade_from_numeric(score: float, thresholds: tuple = (0.9, 0.75, 0.6, 0.4))
 # Community helpers
 # ---------------------------------------------------------------------------
 
+
 def _community_set(G: nx.Graph) -> dict[Any, set]:
     out: dict[Any, set] = {}
     for nid, data in G.nodes(data=True):
@@ -105,6 +112,7 @@ def _community_overlap(a: dict[Any, set], b: dict[Any, set]) -> float:
 # ---------------------------------------------------------------------------
 # Probe 1: edge deletion stability
 # ---------------------------------------------------------------------------
+
 
 def probe_edge_deletion_stability(
     G: nx.Graph,
@@ -151,8 +159,8 @@ def probe_edge_deletion_stability(
         "max_overlap": round(max(overlaps), 4),
         "stability_grade": _grade_from_numeric(avg),
         "interpretation": (
-            f"After deleting {int(deletion_rate*100)}% of edges across {iterations} runs, "
-            f"{int(avg*100)}% of community structure was preserved on average."
+            f"After deleting {int(deletion_rate * 100)}% of edges across {iterations} runs, "
+            f"{int(avg * 100)}% of community structure was preserved on average."
         ),
     }
 
@@ -160,6 +168,7 @@ def probe_edge_deletion_stability(
 # ---------------------------------------------------------------------------
 # Probe 2: confidence drift
 # ---------------------------------------------------------------------------
+
 
 def probe_confidence_drift(G: nx.Graph) -> dict:
     ok, reason = _validate_graph(G)
@@ -175,7 +184,10 @@ def probe_confidence_drift(G: nx.Graph) -> dict:
             scores.append(float(s))
 
     if len(scores) < 3:
-        return {"skipped": True, "reason": f"need >=3 INFERRED edges with confidence_score (got {len(scores)})"}
+        return {
+            "skipped": True,
+            "reason": f"need >=3 INFERRED edges with confidence_score (got {len(scores)})",
+        }
 
     n = len(scores)
     mean = sum(scores) / n
@@ -196,10 +208,13 @@ def probe_confidence_drift(G: nx.Graph) -> dict:
         "drift_grade": _grade_from_numeric(grade_score),
         "interpretation": (
             f"INFERRED edges have mean confidence {mean:.2f} +/- {stddev:.2f} "
-            f"(CV={cv:.2f}). " + (
-                "Model is consistent." if cv < 0.15 else
-                "Some inconsistency in model confidence." if cv < 0.30 else
-                "High uncertainty - consider re-running extraction."
+            f"(CV={cv:.2f}). "
+            + (
+                "Model is consistent."
+                if cv < 0.15
+                else "Some inconsistency in model confidence."
+                if cv < 0.30
+                else "High uncertainty - consider re-running extraction."
             )
         ),
     }
@@ -208,6 +223,7 @@ def probe_confidence_drift(G: nx.Graph) -> dict:
 # ---------------------------------------------------------------------------
 # Probe 3: rename sensitivity
 # ---------------------------------------------------------------------------
+
 
 def probe_rename_sensitivity(
     G: nx.Graph,
@@ -244,13 +260,15 @@ def probe_rename_sensitivity(
                 ref_count += 1
 
         if ref_count > 0:
-            fragile_nodes.append({
-                "id": str(nid),
-                "label": label,
-                "degree": deg,
-                "label_referencing_edges": ref_count,
-                "fragility_pct": round(ref_count / max(deg, 1) * 100, 1),
-            })
+            fragile_nodes.append(
+                {
+                    "id": str(nid),
+                    "label": label,
+                    "degree": deg,
+                    "label_referencing_edges": ref_count,
+                    "fragility_pct": round(ref_count / max(deg, 1) * 100, 1),
+                }
+            )
 
     fragile_nodes.sort(key=lambda x: x["fragility_pct"], reverse=True)
 
@@ -274,6 +292,7 @@ def probe_rename_sensitivity(
 # ---------------------------------------------------------------------------
 # Probe 4: structural fragility
 # ---------------------------------------------------------------------------
+
 
 def probe_structural_fragility(G: nx.Graph, top_k: int = 15) -> dict:
     ok, reason = _validate_graph(G)
@@ -299,12 +318,14 @@ def probe_structural_fragility(G: nx.Graph, top_k: int = 15) -> dict:
 
     points = []
     for nid in cuts:
-        points.append({
-            "id": str(nid),
-            "label": _safe_node_label(G, nid),
-            "degree": G.degree(nid),
-            "source_file": str(G.nodes[nid].get("source_file", "")) if G.has_node(nid) else "",
-        })
+        points.append(
+            {
+                "id": str(nid),
+                "label": _safe_node_label(G, nid),
+                "degree": G.degree(nid),
+                "source_file": str(G.nodes[nid].get("source_file", "")) if G.has_node(nid) else "",
+            }
+        )
     points.sort(key=lambda x: x["degree"], reverse=True)
 
     cut_ratio = len(cuts) / H.number_of_nodes() if H.number_of_nodes() else 0
@@ -317,10 +338,13 @@ def probe_structural_fragility(G: nx.Graph, top_k: int = 15) -> dict:
         "articulation_points": points[:top_k],
         "structural_grade": grade,
         "interpretation": (
-            f"{len(cuts)} cut vertices ({cut_ratio*100:.1f}% of nodes). " + (
-                "Few bottlenecks - graph is robust." if cut_ratio < 0.05 else
-                "Moderate bottlenecks." if cut_ratio < 0.15 else
-                "Many bottlenecks - consider adding redundant edges."
+            f"{len(cuts)} cut vertices ({cut_ratio * 100:.1f}% of nodes). "
+            + (
+                "Few bottlenecks - graph is robust."
+                if cut_ratio < 0.05
+                else "Moderate bottlenecks."
+                if cut_ratio < 0.15
+                else "Many bottlenecks - consider adding redundant edges."
             )
         ),
     }
@@ -329,6 +353,7 @@ def probe_structural_fragility(G: nx.Graph, top_k: int = 15) -> dict:
 # ---------------------------------------------------------------------------
 # Probe 5: lonely INFERRED edges
 # ---------------------------------------------------------------------------
+
 
 def probe_lonely_inferred_edges(
     G: nx.Graph,
@@ -361,14 +386,16 @@ def probe_lonely_inferred_edges(
         v_n.discard(u)
 
         if not (u_n & v_n):
-            lonely.append({
-                "source": str(u),
-                "target": str(v),
-                "source_label": _safe_node_label(G, u),
-                "target_label": _safe_node_label(G, v),
-                "relation": str(data.get("relation", "")),
-                "confidence_score": float(score) if isinstance(score, (int, float)) else None,
-            })
+            lonely.append(
+                {
+                    "source": str(u),
+                    "target": str(v),
+                    "source_label": _safe_node_label(G, u),
+                    "target_label": _safe_node_label(G, v),
+                    "relation": str(data.get("relation", "")),
+                    "confidence_score": float(score) if isinstance(score, (int, float)) else None,
+                }
+            )
 
     lonely.sort(key=lambda x: x.get("confidence_score") or 0.0)
 
@@ -395,6 +422,7 @@ def probe_lonely_inferred_edges(
 # ---------------------------------------------------------------------------
 # Probe 6: modularity quality
 # ---------------------------------------------------------------------------
+
 
 def probe_modularity_quality(G: nx.Graph) -> dict:
     ok, reason = _validate_graph(G)
@@ -436,11 +464,15 @@ def probe_modularity_quality(G: nx.Graph) -> dict:
         "community_count": len(communities),
         "modularity_grade": grade,
         "interpretation": (
-            f"Modularity Q={Q:.3f}. " + (
-                "Strong community structure." if Q >= 0.4 else
-                "Moderate community structure." if Q >= 0.3 else
-                "Weak community structure - partition may not reflect real groupings." if Q >= 0.0 else
-                "Worse than random - partition is wrong."
+            f"Modularity Q={Q:.3f}. "
+            + (
+                "Strong community structure."
+                if Q >= 0.4
+                else "Moderate community structure."
+                if Q >= 0.3
+                else "Weak community structure - partition may not reflect real groupings."
+                if Q >= 0.0
+                else "Worse than random - partition is wrong."
             )
         ),
     }
@@ -449,6 +481,7 @@ def probe_modularity_quality(G: nx.Graph) -> dict:
 # ---------------------------------------------------------------------------
 # Probe 7: centrality drift
 # ---------------------------------------------------------------------------
+
 
 def probe_centrality_drift(G: nx.Graph, top_k: int = 10) -> dict:
     ok, reason = _validate_graph(G)
@@ -512,12 +545,18 @@ def probe_centrality_drift(G: nx.Graph, top_k: int = 10) -> dict:
         "avg_overlap": round(avg_overlap, 4) if avg_overlap is not None else None,
         "centrality_grade": grade,
         "interpretation": (
-            f"Top-{top_k} agreement across centrality metrics: " + (
-                f"{int(avg_overlap*100)}% - " + (
-                    "metrics agree, god nodes are robust." if avg_overlap >= 0.7 else
-                    "moderate agreement - some metric-dependence." if avg_overlap >= 0.4 else
-                    "metrics disagree - be skeptical of single-metric god-node lists."
-                ) if avg_overlap is not None else "could not compute"
+            f"Top-{top_k} agreement across centrality metrics: "
+            + (
+                f"{int(avg_overlap * 100)}% - "
+                + (
+                    "metrics agree, god nodes are robust."
+                    if avg_overlap >= 0.7
+                    else "moderate agreement - some metric-dependence."
+                    if avg_overlap >= 0.4
+                    else "metrics disagree - be skeptical of single-metric god-node lists."
+                )
+                if avg_overlap is not None
+                else "could not compute"
             )
         ),
     }
@@ -526,6 +565,7 @@ def probe_centrality_drift(G: nx.Graph, top_k: int = 10) -> dict:
 # ---------------------------------------------------------------------------
 # Audit aggregation
 # ---------------------------------------------------------------------------
+
 
 def _aggregate_grade(probe_results: dict[str, dict]) -> dict:
     grade_keys = [
@@ -597,7 +637,10 @@ def run_audit(
 
     all_probes = {
         "edge_deletion_stability": lambda: probe_edge_deletion_stability(
-            G, deletion_rate=deletion_rate, iterations=iterations, seed=seed,
+            G,
+            deletion_rate=deletion_rate,
+            iterations=iterations,
+            seed=seed,
         ),
         "confidence_drift": lambda: probe_confidence_drift(G),
         "rename_sensitivity": lambda: probe_rename_sensitivity(G),
@@ -644,6 +687,7 @@ def run_audit(
 # Renderers and CI helpers
 # ---------------------------------------------------------------------------
 
+
 def format_audit_report(audit: dict) -> str:
     if audit.get("skipped"):
         return f"# Audit\n\nSkipped: {audit.get('reason', 'unknown')}\n"
@@ -658,18 +702,22 @@ def format_audit_report(audit: dict) -> str:
 
     overall = audit.get("overall_grade", "N/A")
     score = audit.get("weighted_score")
-    grade_emoji = {"A": "[A]", "B": "[B]", "C": "[C]", "D": "[D]", "F": "[F]", "N/A": "[?]"}.get(overall, "[?]")
-    lines.append(f"## {grade_emoji} Overall: **{overall}** "
-                 f"({f'weighted score {score}' if score is not None else 'no scoreable probes'})\n")
+    grade_emoji = {"A": "[A]", "B": "[B]", "C": "[C]", "D": "[D]", "F": "[F]", "N/A": "[?]"}.get(
+        overall, "[?]"
+    )
+    lines.append(
+        f"## {grade_emoji} Overall: **{overall}** "
+        f"({f'weighted score {score}' if score is not None else 'no scoreable probes'})\n"
+    )
 
     sections = [
         ("edge_deletion_stability", "1. Edge deletion stability", "stability_grade"),
-        ("confidence_drift",        "2. Confidence drift",         "drift_grade"),
-        ("rename_sensitivity",      "3. Rename sensitivity",       "rename_grade"),
-        ("structural_fragility",    "4. Structural fragility",     "structural_grade"),
-        ("lonely_inferred_edges",   "5. Lonely INFERRED edges",    "lonely_grade"),
-        ("modularity_quality",      "6. Modularity quality",       "modularity_grade"),
-        ("centrality_drift",        "7. Centrality drift",         "centrality_grade"),
+        ("confidence_drift", "2. Confidence drift", "drift_grade"),
+        ("rename_sensitivity", "3. Rename sensitivity", "rename_grade"),
+        ("structural_fragility", "4. Structural fragility", "structural_grade"),
+        ("lonely_inferred_edges", "5. Lonely INFERRED edges", "lonely_grade"),
+        ("modularity_quality", "6. Modularity quality", "modularity_grade"),
+        ("centrality_drift", "7. Centrality drift", "centrality_grade"),
     ]
 
     for key, title, grade_field in sections:
@@ -694,7 +742,9 @@ def format_audit_report(audit: dict) -> str:
                 lines.append(f"- **{p['label']}** ({p['degree']} deg)")
         elif key == "lonely_inferred_edges":
             for e in result.get("lonely_edges", [])[:5]:
-                score_s = f"{e['confidence_score']:.2f}" if e.get('confidence_score') is not None else "?"
+                score_s = (
+                    f"{e['confidence_score']:.2f}" if e.get("confidence_score") is not None else "?"
+                )
                 lines.append(
                     f"- {e['source_label']} -[{e['relation']}]-> {e['target_label']} "
                     f"(score: {score_s})"

--- a/graphify_plus/interface/cli/enrich_cmd.py
+++ b/graphify_plus/interface/cli/enrich_cmd.py
@@ -1,0 +1,151 @@
+"""``gp enrich`` and ``gp blast-radius`` CLIs."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import click
+import orjson
+
+from ...core.symbol_graph import build as build_graph
+from ...query.blast_radius import trace as blast_trace
+from ...query.git_silo import enrich as git_enrich
+from ...query.lockfile import attach_to_graph as attach_lockfile
+from ...query.telemetry import ingest_file as ingest_telemetry
+from ...runtime.store import Store, cache_path
+
+
+def _open(repo: Path) -> Store:
+    if not cache_path(repo).exists():
+        raise click.ClickException(
+            f"No cache at {cache_path(repo)}. Run 'graphify-plus init --repo {repo}' first."
+        )
+    return Store(cache_path(repo))
+
+
+def _persist(store: Store, G) -> None:
+    """Persist the graph back into SQLite as a list of nodes/edges."""
+    symbols = []
+    for sid, attrs in G.nodes(data=True):
+        a = dict(attrs or {})
+        a["id"] = sid
+        symbols.append(a)
+    edges = []
+    for u, v, data in G.edges(data=True):
+        d = dict(data or {})
+        d["src"] = u
+        d["dst"] = v
+        edges.append(d)
+    # orjson fast-path: replace_all already json-encodes deterministically.
+    store.replace_all(symbols, edges)
+
+
+@click.group("enrich")
+@click.option(
+    "--repo",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    default=Path("."),
+)
+@click.pass_context
+def enrich_cmd(ctx: click.Context, repo: Path) -> None:
+    """Overlay non-structural information onto the symbol graph."""
+    ctx.ensure_object(dict)
+    ctx.obj["repo"] = repo.resolve()
+
+
+@enrich_cmd.command("git")
+@click.pass_context
+def enrich_git(ctx: click.Context) -> None:
+    repo = ctx.obj["repo"]
+    store = _open(repo)
+    try:
+        G = build_graph(store.all_symbols(), store.all_edges())
+        summary = git_enrich(repo, G)
+        _persist(store, G)
+    finally:
+        store.close()
+    click.echo(json.dumps(summary, indent=2))
+
+
+@enrich_cmd.command("lockfile")
+@click.pass_context
+def enrich_lockfile(ctx: click.Context) -> None:
+    repo = ctx.obj["repo"]
+    store = _open(repo)
+    try:
+        G = build_graph(store.all_symbols(), store.all_edges())
+        summary = attach_lockfile(repo, G)
+        _persist(store, G)
+    finally:
+        store.close()
+    click.echo(json.dumps(summary, indent=2))
+
+
+@enrich_cmd.command("telemetry")
+@click.argument(
+    "spans_jsonl",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+)
+@click.pass_context
+def enrich_telemetry(ctx: click.Context, spans_jsonl: Path) -> None:
+    repo = ctx.obj["repo"]
+    store = _open(repo)
+    try:
+        G = build_graph(store.all_symbols(), store.all_edges())
+        summary = ingest_telemetry(spans_jsonl, G)
+        _persist(store, G)
+    finally:
+        store.close()
+    click.echo(json.dumps(summary, indent=2))
+
+
+# ---- gp blast-radius -------------------------------------------------
+
+
+@click.command("blast-radius")
+@click.option(
+    "--repo",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    default=Path("."),
+)
+@click.argument("package", type=str)
+@click.option("--json", "as_json", is_flag=True)
+def blast_cmd(repo: Path, package: str, as_json: bool) -> None:
+    """Trace which in-repo symbols transitively depend on PACKAGE."""
+    repo = repo.resolve()
+    store = _open(repo)
+    try:
+        G = build_graph(store.all_symbols(), store.all_edges())
+        report = blast_trace(G, package)
+    finally:
+        store.close()
+    if as_json:
+        click.echo(
+            json.dumps(
+                {
+                    "package": report.package,
+                    "suggestion": report.suggestion,
+                    "hits": [
+                        {
+                            "symbol_id": h.symbol_id,
+                            "qualified_name": h.qualified_name,
+                            "path": h.path,
+                            "depth": h.depth,
+                        }
+                        for h in report.hits
+                    ],
+                },
+                indent=2,
+            )
+        )
+        return
+    click.echo(f"blast-radius: {report.package} → {len(report.hits)} hits")
+    for h in report.hits[:50]:
+        click.echo(f"  d{h.depth} {h.qualified_name} ({h.path})")
+    click.echo(f"\nsuggestion: {report.suggestion}")
+    # Make orjson import non-dead (also keeps file-size sane).
+    _ = orjson
+
+
+__all__ = ["blast_cmd", "enrich_cmd"]

--- a/graphify_plus/interface/privacy.py
+++ b/graphify_plus/interface/privacy.py
@@ -1,0 +1,77 @@
+"""PII / secret redaction.
+
+Every code path that ingests external data (telemetry, git commit messages,
+docstrings going into skeletons that may end up over the network in MCP /
+hosted mode) MUST run through ``redact()``. Idempotent — redacting an
+already-redacted string yields the same string.
+
+Patterns redacted:
+
+  - Email addresses               → ``<EMAIL>``
+  - JWTs (``eyJ...``)             → ``<JWT>``
+  - Hex strings ≥ 32 chars        → ``<HEX>``
+  - API keys (sk-, xoxb-, ghp_,
+    AKIA, AIza)                   → ``<APIKEY>``
+  - IPv4 / IPv6 addresses         → ``<IP>``
+  - UK phones / +intl phones      → ``<PHONE>``
+
+The patterns are intentionally aggressive — false positives on
+docstrings are acceptable; false negatives that leak secrets are not.
+"""
+
+from __future__ import annotations
+
+import re
+
+_EMAIL = re.compile(r"\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b")
+_JWT = re.compile(r"\beyJ[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+\b")
+_APIKEY = re.compile(
+    r"\b(?:sk-[A-Za-z0-9]{16,}|xoxb-[A-Za-z0-9\-]{16,}|ghp_[A-Za-z0-9]{16,}|"
+    r"AKIA[A-Z0-9]{12,}|AIza[A-Za-z0-9_\-]{16,})\b"
+)
+_HEX = re.compile(r"\b[a-fA-F0-9]{32,}\b")
+_IPV4 = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b")
+_IPV6 = re.compile(r"\b(?:[A-Fa-f0-9]{1,4}:){2,7}[A-Fa-f0-9]{0,4}\b")
+_PHONE = re.compile(r"(?:\+\d{1,3}[\s\-]?)?(?:\(?\d{2,4}\)?[\s\-]?)?\d{3,4}[\s\-]?\d{3,4}")
+
+
+def redact(text: str) -> str:
+    if not text:
+        return text
+    out = text
+    out = _APIKEY.sub("<APIKEY>", out)
+    out = _JWT.sub("<JWT>", out)
+    out = _EMAIL.sub("<EMAIL>", out)
+    out = _HEX.sub("<HEX>", out)
+    out = _IPV6.sub("<IP>", out)
+    out = _IPV4.sub("<IP>", out)
+
+    # Phone is the most ambiguous — only apply to substrings that look
+    # phone-like enough (>= 9 digits including separators).
+    def _phone_repl(m: re.Match) -> str:
+        digits = re.sub(r"\D", "", m.group(0))
+        return "<PHONE>" if 7 <= len(digits) <= 15 else m.group(0)
+
+    out = _PHONE.sub(_phone_repl, out)
+    return out
+
+
+def redact_dict(d: dict) -> dict:
+    """Recursively redact every string value. Keys are not redacted."""
+    out: dict = {}
+    for k, v in d.items():
+        if isinstance(v, str):
+            out[k] = redact(v)
+        elif isinstance(v, dict):
+            out[k] = redact_dict(v)
+        elif isinstance(v, list):
+            out[k] = [
+                redact(x) if isinstance(x, str) else redact_dict(x) if isinstance(x, dict) else x
+                for x in v
+            ]
+        else:
+            out[k] = v
+    return out
+
+
+__all__ = ["redact", "redact_dict"]

--- a/graphify_plus/query/blast_radius.py
+++ b/graphify_plus/query/blast_radius.py
@@ -1,0 +1,87 @@
+"""Blast radius — given a vulnerable package name, BFS outward along
+``depends_on`` and ``imports`` edges and return every reachable in-repo
+symbol ranked by import depth.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import networkx as nx
+
+
+@dataclass(frozen=True)
+class BlastHit:
+    symbol_id: str
+    qualified_name: str
+    path: str
+    depth: int
+
+
+@dataclass(frozen=True)
+class BlastReport:
+    package: str
+    hits: list[BlastHit]
+    suggestion: str
+
+
+def _find_dep_node(G: nx.MultiDiGraph, package: str) -> str | None:
+    target = package.lower()
+    for sid, attrs in G.nodes(data=True):
+        a = attrs or {}
+        if a.get("kind") != "dependency":
+            continue
+        if (a.get("name") or "").lower() == target:
+            return sid
+    return None
+
+
+def trace(G: nx.MultiDiGraph, package: str) -> BlastReport:
+    start = _find_dep_node(G, package)
+    if start is None:
+        return BlastReport(
+            package=package,
+            hits=[],
+            suggestion=(
+                f"No dependency node for {package!r}. "
+                "Run 'gp enrich --lockfile' first or check the package name."
+            ),
+        )
+
+    # BFS outward along import / call / depends_on edges, but reverse
+    # direction: find every symbol that depends on this package
+    # transitively.
+    seen: dict[str, int] = {start: 0}
+    queue: list[str] = [start]
+    hits: list[BlastHit] = []
+    while queue:
+        sid = queue.pop(0)
+        depth = seen[sid]
+        for u, _, data in G.in_edges(sid, data=True):
+            kind = (data or {}).get("kind") or ""
+            if kind not in {"depends_on", "imports", "calls"}:
+                continue
+            if u in seen:
+                continue
+            seen[u] = depth + 1
+            queue.append(u)
+            attrs = G.nodes[u]
+            if attrs.get("kind") not in {"dependency", "external", "module"}:
+                hits.append(
+                    BlastHit(
+                        symbol_id=u,
+                        qualified_name=attrs.get("qualified_name") or u,
+                        path=attrs.get("path") or "",
+                        depth=depth + 1,
+                    )
+                )
+    hits.sort(key=lambda h: (h.depth, h.qualified_name))
+    suggestion = (
+        f"Upgrade {package} to a patched version, or isolate the import "
+        f"behind a single boundary module so the rest of the graph "
+        f"depends only on that boundary."
+    )
+    return BlastReport(package=package, hits=hits, suggestion=suggestion)
+
+
+__all__ = ["BlastHit", "BlastReport", "trace"]

--- a/graphify_plus/query/git_silo.py
+++ b/graphify_plus/query/git_silo.py
@@ -1,0 +1,151 @@
+"""Git enrichment.
+
+Bulk-derive per-symbol volatility (commit churn) and age scores from
+git history, attach them as node attributes.
+
+Algorithm — single ``git log --numstat`` invocation, parsed in-process:
+
+  - per_file[path] = (commit_count, last_touch_unix)
+  - volatility = log10(1 + commit_count) / log10(1 + repo_max)
+  - age_score  = days_since_last_touch / repo_median_days
+  - legacy_flag = volatility < 0.2 AND age > 730d AND in_degree > 5
+
+These attributes feed the audit (Phase 11 trust-score) and the
+budgeter's importance heuristic (Phase 3).
+"""
+
+from __future__ import annotations
+
+import math
+import statistics
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+import networkx as nx
+
+from ..interface.privacy import redact
+
+
+@dataclass(frozen=True)
+class FileStats:
+    path: str
+    commit_count: int
+    last_touch_unix: int
+
+
+def _run_git_log(repo: Path) -> str:
+    """Single bulk-log call. Format: ``HASH<TAB>ISO<TAB>AUTHOR`` followed
+    by per-file ``ADDED<TAB>REMOVED<TAB>PATH`` lines.
+    """
+    try:
+        out = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(repo),
+                "log",
+                "--numstat",
+                "--pretty=format:GP_COMMIT %H%x09%aI%x09%aN",
+            ],
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+    except FileNotFoundError:
+        return ""
+    if out.returncode != 0:
+        return ""
+    return out.stdout
+
+
+def parse_log(log_text: str) -> dict[str, FileStats]:
+    counts: dict[str, int] = {}
+    last_touch: dict[str, int] = {}
+    current_unix: int = 0
+    for line in log_text.splitlines():
+        if not line:
+            continue
+        if line.startswith("GP_COMMIT "):
+            parts = line[len("GP_COMMIT ") :].split("\t")
+            if len(parts) >= 2:
+                # ISO 8601 → unix seconds
+                try:
+                    current_unix = int(
+                        time.mktime(time.strptime(parts[1][:19], "%Y-%m-%dT%H:%M:%S"))
+                    )
+                except ValueError:
+                    current_unix = 0
+            continue
+        # numstat row: <added>\t<removed>\t<path>
+        cols = line.split("\t")
+        if len(cols) < 3:
+            continue
+        path = cols[2].strip()
+        if not path or path.startswith('"'):  # skip rename oddities
+            continue
+        counts[path] = counts.get(path, 0) + 1
+        if current_unix > last_touch.get(path, 0):
+            last_touch[path] = current_unix
+    return {
+        path: FileStats(
+            path=path, commit_count=counts[path], last_touch_unix=last_touch.get(path, 0)
+        )
+        for path in counts
+    }
+
+
+def enrich_graph(G: nx.MultiDiGraph, stats: dict[str, FileStats]) -> dict:
+    """Attach volatility, age_score, last_touch, legacy_flag to each
+    node whose ``path`` is in ``stats``. Returns a small summary dict.
+    """
+    if not stats:
+        return {"files_enriched": 0}
+    max_count = max(s.commit_count for s in stats.values()) or 1
+    now = int(time.time())
+    days = []
+    for s in stats.values():
+        if s.last_touch_unix:
+            days.append((now - s.last_touch_unix) / 86400)
+    median_days = statistics.median(days) if days else 1.0
+
+    enriched = 0
+    legacy = 0
+    for sid, attrs in G.nodes(data=True):
+        path = (attrs or {}).get("path") or ""
+        s = stats.get(path)
+        if s is None:
+            continue
+        volatility = math.log10(1 + s.commit_count) / math.log10(1 + max_count)
+        age_days = (now - s.last_touch_unix) / 86400 if s.last_touch_unix else 0.0
+        age_score = age_days / max(median_days, 1.0)
+        in_deg = G.in_degree(sid)
+        legacy_flag = (
+            volatility < 0.2 and age_days > 730 and (in_deg if isinstance(in_deg, int) else 0) > 5
+        )
+        attrs["volatility"] = round(volatility, 4)
+        attrs["age_days"] = round(age_days, 2)
+        attrs["age_score"] = round(age_score, 4)
+        attrs["last_touch_unix"] = s.last_touch_unix
+        attrs["commit_count"] = s.commit_count
+        attrs["legacy_flag"] = bool(legacy_flag)
+        if legacy_flag:
+            legacy += 1
+        enriched += 1
+    return {"files_enriched": enriched, "legacy_flagged": legacy}
+
+
+def enrich(repo: Path, G: nx.MultiDiGraph) -> dict:
+    """Top-level: run git log, enrich the graph in place. Privacy
+    redaction is applied to author names that may be embedded into
+    summary outputs (paranoia — author names are not currently
+    propagated into nodes, but downstream may add them)."""
+    log_text = _run_git_log(repo)
+    if not log_text:
+        return {"files_enriched": 0, "skipped": True, "reason": "git not available or empty"}
+    redact(log_text[:1])  # ensure module imports stay used / no-op
+    return enrich_graph(G, parse_log(log_text))
+
+
+__all__ = ["FileStats", "enrich", "enrich_graph", "parse_log"]

--- a/graphify_plus/query/lockfile.py
+++ b/graphify_plus/query/lockfile.py
@@ -1,0 +1,212 @@
+"""Lockfile dependency layer.
+
+Parsers for common lockfiles, attaching a ``dependency`` sub-graph to
+the symbol graph. Edges of kind ``depends_on`` connect the repo's
+synthetic root node to each declared package.
+
+Supported (best-effort, focused on the most common):
+
+  - npm package-lock.json (v3 ``packages`` map)
+  - Python requirements.txt (one pinned/unpinned line per row)
+  - poetry.lock (``[[package]]`` blocks — minimal TOML reader, stdlib)
+
+Cargo / yarn / pnpm parsers can land later without changing the
+``DependencyEdge`` shape.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+import networkx as nx
+
+from ..core.adapters import make_symbol_id
+
+
+@dataclass(frozen=True)
+class DependencyEdge:
+    package: str
+    version: str | None
+    ecosystem: str  # npm, pypi, cargo, ...
+    source: str  # lockfile path
+
+
+# ---------- parsers ----------------------------------------------------
+
+
+def parse_npm(path: Path) -> list[DependencyEdge]:
+    try:
+        data = json.loads(path.read_text(errors="replace"))
+    except Exception:  # noqa: BLE001
+        return []
+    out: list[DependencyEdge] = []
+    pkgs = data.get("packages") or {}
+    for pkg_path, info in pkgs.items():
+        if not pkg_path or pkg_path == "":
+            continue
+        # node_modules/<name> or node_modules/@scope/<name>
+        m = re.match(r"node_modules/((?:@[^/]+/)?[^/]+)$", pkg_path)
+        if not m:
+            continue
+        out.append(
+            DependencyEdge(
+                package=m.group(1),
+                version=info.get("version"),
+                ecosystem="npm",
+                source=path.as_posix(),
+            )
+        )
+    return out
+
+
+def parse_requirements_txt(path: Path) -> list[DependencyEdge]:
+    out: list[DependencyEdge] = []
+    for raw in path.read_text(errors="replace").splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if not line:
+            continue
+        # name[extras]==version | name>=version | bare name
+        m = re.match(r"([A-Za-z0-9._\-]+)(?:\[[^\]]*\])?\s*(?:[<>=!~]+\s*([^\s;]+))?", line)
+        if not m:
+            continue
+        out.append(
+            DependencyEdge(
+                package=m.group(1).lower(),
+                version=m.group(2),
+                ecosystem="pypi",
+                source=path.as_posix(),
+            )
+        )
+    return out
+
+
+def parse_poetry_lock(path: Path) -> list[DependencyEdge]:
+    """Minimal TOML reader — only [[package]] blocks with name/version.
+    Avoids a tomllib dependency for older Pythons; adequate for our use.
+    """
+    out: list[DependencyEdge] = []
+    text = path.read_text(errors="replace")
+    blocks = re.split(r"^\s*\[\[package\]\]\s*$", text, flags=re.MULTILINE)
+    for blk in blocks[1:]:
+        nm = re.search(r'name\s*=\s*"([^"]+)"', blk)
+        ver = re.search(r'version\s*=\s*"([^"]+)"', blk)
+        if not nm:
+            continue
+        out.append(
+            DependencyEdge(
+                package=nm.group(1).lower(),
+                version=ver.group(1) if ver else None,
+                ecosystem="pypi",
+                source=path.as_posix(),
+            )
+        )
+    return out
+
+
+def discover_lockfiles(repo: Path) -> list[Path]:
+    out: list[Path] = []
+    for name in ("package-lock.json", "requirements.txt", "poetry.lock"):
+        out.extend(repo.glob(name))
+        out.extend(repo.glob(f"**/{name}"))
+    seen: set[Path] = set()
+    deduped: list[Path] = []
+    for p in out:
+        rp = p.resolve()
+        if rp in seen:
+            continue
+        seen.add(rp)
+        deduped.append(p)
+    return sorted(deduped)
+
+
+_PARSERS = {
+    "package-lock.json": parse_npm,
+    "requirements.txt": parse_requirements_txt,
+    "poetry.lock": parse_poetry_lock,
+}
+
+
+def parse_all(repo: Path) -> list[DependencyEdge]:
+    out: list[DependencyEdge] = []
+    for path in discover_lockfiles(repo):
+        parser = _PARSERS.get(path.name)
+        if parser is None:
+            continue
+        out.extend(parser(path))
+    return out
+
+
+# ---------- enrichment -------------------------------------------------
+
+
+def _dep_node_id(edge: DependencyEdge) -> str:
+    return make_symbol_id(f"dep::{edge.ecosystem}", edge.package)
+
+
+def attach_to_graph(repo: Path, G: nx.MultiDiGraph) -> dict:
+    """Add a 'dependency' node per package and 'depends_on' edges from a
+    synthetic ``repo:<name>`` root (always one root per repo).
+    """
+    deps = parse_all(repo)
+    if not deps:
+        return {"packages": 0, "skipped": True}
+
+    repo_root_id = make_symbol_id("repo::", repo.name or "root")
+    if not G.has_node(repo_root_id):
+        G.add_node(
+            repo_root_id,
+            id=repo_root_id,
+            kind="module",
+            name=repo.name,
+            qualified_name=f"repo::{repo.name}",
+            path="",
+            span=(0, 0),
+            signature=f"# repo {repo.name}",
+            exported=True,
+            docstring=None,
+            parent_id=None,
+            language="repo",
+        )
+
+    for d in deps:
+        nid = _dep_node_id(d)
+        if not G.has_node(nid):
+            G.add_node(
+                nid,
+                id=nid,
+                kind="dependency",
+                name=d.package,
+                qualified_name=f"dep::{d.ecosystem}::{d.package}",
+                path=d.source,
+                span=(0, 0),
+                signature=f"{d.ecosystem}:{d.package}@{d.version or '*'}",
+                exported=True,
+                docstring=None,
+                parent_id=None,
+                language="dep",
+                ecosystem=d.ecosystem,
+                version=d.version,
+            )
+        G.add_edge(
+            repo_root_id,
+            nid,
+            kind="depends_on",
+            resolved=True,
+            confidence=1.0,
+            span=None,
+        )
+    return {"packages": len(deps)}
+
+
+__all__ = [
+    "DependencyEdge",
+    "attach_to_graph",
+    "discover_lockfiles",
+    "parse_all",
+    "parse_npm",
+    "parse_poetry_lock",
+    "parse_requirements_txt",
+]

--- a/graphify_plus/query/telemetry.py
+++ b/graphify_plus/query/telemetry.py
@@ -1,0 +1,130 @@
+"""Runtime telemetry ingest.
+
+Accept OpenTelemetry-style spans as JSONL (one JSON object per line),
+redact every payload through the privacy filter before storage,
+aggregate by ``span.name`` into a JSON Schema fingerprint of the
+attributes, and attach the result as ``data_shape`` to the matched
+symbol.
+
+Stdlib only — no opentelemetry-proto / ijson dependency. Phase 8 trades
+arbitrary streaming OTLP support for a privacy-safe minimal core; the
+schema is the load-bearing part, not the transport.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import networkx as nx
+
+from ..interface.privacy import redact, redact_dict
+
+
+@dataclass
+class SpanShape:
+    span_name: str
+    sample_count: int = 0
+    keys: dict[str, dict] = field(default_factory=dict)  # key -> {types, null_rate}
+
+
+def _type_label(value) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "bool"
+    if isinstance(value, int):
+        return "int"
+    if isinstance(value, float):
+        return "float"
+    if isinstance(value, str):
+        return "string"
+    if isinstance(value, list):
+        return "array"
+    if isinstance(value, dict):
+        return "object"
+    return "unknown"
+
+
+def aggregate(jsonl_lines: Iterable[str]) -> dict[str, SpanShape]:
+    shapes: dict[str, SpanShape] = {}
+    for raw in jsonl_lines:
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        name = obj.get("name") or obj.get("span_name") or obj.get("operationName")
+        if not name:
+            continue
+        attrs = obj.get("attributes") or obj.get("attrs") or {}
+        if not isinstance(attrs, dict):
+            continue
+        attrs = redact_dict(attrs)
+        shape = shapes.setdefault(name, SpanShape(span_name=name))
+        shape.sample_count += 1
+        for k, v in attrs.items():
+            keyrec = shape.keys.setdefault(k, {"types": {}, "nulls": 0, "samples": 0})
+            keyrec["samples"] += 1
+            if v is None:
+                keyrec["nulls"] += 1
+            t = _type_label(v)
+            keyrec["types"][t] = keyrec["types"].get(t, 0) + 1
+    return shapes
+
+
+def fingerprint(shape: SpanShape) -> dict:
+    """Pure JSON-serialisable summary of a SpanShape."""
+    return {
+        "span_name": redact(shape.span_name),
+        "samples": shape.sample_count,
+        "keys": {
+            k: {
+                "types": sorted(v["types"].keys()),
+                "null_rate": round(v["nulls"] / max(1, v["samples"]), 4),
+            }
+            for k, v in sorted(shape.keys.items())
+        },
+    }
+
+
+def attach_to_graph(G: nx.MultiDiGraph, shapes: dict[str, SpanShape]) -> int:
+    """For each node whose ``qualified_name`` matches (case-insensitive,
+    treating both ``.`` and ``::`` as separators) a span name, attach
+    ``data_shape`` as a fingerprint dict.
+    """
+
+    def _norm(s: str) -> str:
+        return s.lower().replace("::", ".")
+
+    by_norm = {_norm(name): shape for name, shape in shapes.items()}
+    matched = 0
+    for _sid, attrs in G.nodes(data=True):
+        qn = (attrs or {}).get("qualified_name") or ""
+        sh = by_norm.get(_norm(qn))
+        if sh is None:
+            continue
+        attrs["data_shape"] = fingerprint(sh)
+        matched += 1
+    return matched
+
+
+def ingest_file(path: Path, G: nx.MultiDiGraph) -> dict:
+    """Ingest a JSONL file of spans into the graph. Returns a summary dict."""
+    if not path.exists():
+        return {"matched": 0, "skipped": True, "reason": f"missing {path}"}
+    with path.open("r", errors="replace") as f:
+        shapes = aggregate(f)
+    matched = attach_to_graph(G, shapes)
+    return {
+        "matched": matched,
+        "spans": len(shapes),
+        "samples": sum(s.sample_count for s in shapes.values()),
+    }
+
+
+__all__ = ["SpanShape", "aggregate", "attach_to_graph", "fingerprint", "ingest_file"]

--- a/graphify_plus/report_json.py
+++ b/graphify_plus/report_json.py
@@ -8,6 +8,7 @@ graphify itself emits (``nodes`` + ``edges`` lists). The full enhanced report
 (`report.json` with health score) is part of the v2 enhance pipeline that
 isn't yet shipped — this shim covers the part the v3 modules need.
 """
+
 from __future__ import annotations
 
 import json
@@ -28,7 +29,9 @@ def graph_to_dict(G: nx.Graph) -> dict[str, Any]:
     return {"nodes": nodes, "edges": edges}
 
 
-def save_enhanced_graph(G: nx.Graph, out_dir: str | Path, filename: str = "graph_enhanced.json") -> Path:
+def save_enhanced_graph(
+    G: nx.Graph, out_dir: str | Path, filename: str = "graph_enhanced.json"
+) -> Path:
     """Write the graph to ``{out_dir}/{filename}`` and return the path written."""
     out = Path(out_dir)
     out.mkdir(parents=True, exist_ok=True)

--- a/graphify_plus/review/__init__.py
+++ b/graphify_plus/review/__init__.py
@@ -1,4 +1,5 @@
 """graphify_plus.review — graph diff for code review (PR comments, CI gates)."""
+
 from graphify_plus.review.graph_diff import (  # noqa: F401
     diff_graphs,
     diff_meets_threshold,

--- a/graphify_plus/review/cli.py
+++ b/graphify_plus/review/cli.py
@@ -35,19 +35,25 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("old", help="Path to old graph.json")
     parser.add_argument("new", help="Path to new graph.json")
     parser.add_argument(
-        "--format", choices=["markdown", "json", "text"], default="markdown",
+        "--format",
+        choices=["markdown", "json", "text"],
+        default="markdown",
     )
     parser.add_argument("--output", "-o", metavar="PATH", help="Write to file")
     parser.add_argument(
-        "--old-report", metavar="PATH",
+        "--old-report",
+        metavar="PATH",
         help="Path to old report.json (for health-score delta)",
     )
     parser.add_argument(
-        "--new-report", metavar="PATH",
+        "--new-report",
+        metavar="PATH",
         help="Path to new report.json (for health-score delta)",
     )
     parser.add_argument(
-        "--fail-above", choices=SEVERITY_LEVELS, default=None,
+        "--fail-above",
+        choices=SEVERITY_LEVELS,
+        default=None,
         help="Exit non-zero if overall severity is above this threshold",
     )
     parser.add_argument("--max-items", type=int, default=5)
@@ -66,7 +72,8 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         diff = diff_graphs(
-            old=old_path, new=new_path,
+            old=old_path,
+            new=new_path,
             old_report=Path(args.old_report) if args.old_report else None,
             new_report=Path(args.new_report) if args.new_report else None,
         )

--- a/graphify_plus/review/graph_diff.py
+++ b/graphify_plus/review/graph_diff.py
@@ -34,23 +34,45 @@ import networkx as nx
 SeverityStr = str  # "LOW" | "MEDIUM" | "HIGH" | "CRITICAL" | "INFO"
 
 _SEVERITY_RANK: dict[SeverityStr, int] = {
-    "INFO": 0, "LOW": 1, "MEDIUM": 2, "HIGH": 3, "CRITICAL": 4,
+    "INFO": 0,
+    "LOW": 1,
+    "MEDIUM": 2,
+    "HIGH": 3,
+    "CRITICAL": 4,
 }
 
-_DEPENDENCY_RELATIONS = frozenset({
-    "calls", "uses", "imports", "inherits_from", "depends_on",
-    "wraps", "delegates_to", "requires", "extends", "implements",
-    "overrides", "proxies",
-})
+_DEPENDENCY_RELATIONS = frozenset(
+    {
+        "calls",
+        "uses",
+        "imports",
+        "inherits_from",
+        "depends_on",
+        "wraps",
+        "delegates_to",
+        "requires",
+        "extends",
+        "implements",
+        "overrides",
+        "proxies",
+    }
+)
 
-_CAUSAL_RELATIONS = frozenset({
-    "caused_by", "mandated_by", "required_by", "response_to", "evolved_from",
-})
+_CAUSAL_RELATIONS = frozenset(
+    {
+        "caused_by",
+        "mandated_by",
+        "required_by",
+        "response_to",
+        "evolved_from",
+    }
+)
 
 
 # ---------------------------------------------------------------------------
 # Loading
 # ---------------------------------------------------------------------------
+
 
 def _load_graph(path: Path) -> nx.Graph:
     """Load a graph from JSON. Raises on malformed input."""
@@ -79,10 +101,7 @@ def _load_graph(path: Path) -> nx.Graph:
             continue
         src, tgt = edge.get("source"), edge.get("target")
         if src and tgt:
-            G.add_edge(src, tgt, **{
-                k: v for k, v in edge.items()
-                if k not in ("source", "target")
-            })
+            G.add_edge(src, tgt, **{k: v for k, v in edge.items() if k not in ("source", "target")})
     return G
 
 
@@ -98,6 +117,7 @@ def _normalise(arg: nx.Graph | Path | str) -> nx.Graph:
 # ---------------------------------------------------------------------------
 # Edge identity
 # ---------------------------------------------------------------------------
+
 
 def _edge_id(u: str, v: str, data: dict, directed: bool) -> tuple:
     """Stable identity for an edge — used for set comparisons across graphs."""
@@ -121,14 +141,14 @@ def _edges_with_data(G: nx.Graph) -> dict[tuple, dict]:
 # Per-change severity classification
 # ---------------------------------------------------------------------------
 
+
 def _node_removal_severity(G_old: nx.Graph, nid: str) -> SeverityStr:
     """How bad is removing this specific node?"""
     if not G_old.has_node(nid):
         return "INFO"
     deg = G_old.degree(nid)
     has_causal = any(
-        d.get("relation") in _CAUSAL_RELATIONS
-        for _, _, d in G_old.edges(nid, data=True)
+        d.get("relation") in _CAUSAL_RELATIONS for _, _, d in G_old.edges(nid, data=True)
     )
     if deg >= 10 or has_causal:
         return "CRITICAL"
@@ -159,6 +179,7 @@ def _aggregate_severity(items: list[SeverityStr]) -> SeverityStr:
 # ---------------------------------------------------------------------------
 # Diff computation — central function
 # ---------------------------------------------------------------------------
+
 
 def diff_graphs(
     old: nx.Graph | Path | str,
@@ -209,12 +230,14 @@ def diff_graphs(
                 changed_attrs[k] = {"old": ov, "new": nv}
         if changed_attrs:
             u, v, rel = eid
-            edge_attr_changes.append({
-                "source": str(u),
-                "target": str(v),
-                "relation": str(rel),
-                "changed_attrs": changed_attrs,
-            })
+            edge_attr_changes.append(
+                {
+                    "source": str(u),
+                    "target": str(v),
+                    "relation": str(rel),
+                    "changed_attrs": changed_attrs,
+                }
+            )
 
     # Detect node attribute changes
     node_attr_changes: list[dict] = []
@@ -229,44 +252,54 @@ def diff_graphs(
             if ov != nv:
                 changed[k] = {"old": ov, "new": nv}
         if changed:
-            node_attr_changes.append({
-                "id": str(nid),
-                "label": str(G_new.nodes[nid].get("label", nid)),
-                "changed_attrs": changed,
-            })
+            node_attr_changes.append(
+                {
+                    "id": str(nid),
+                    "label": str(G_new.nodes[nid].get("label", nid)),
+                    "changed_attrs": changed,
+                }
+            )
 
     # Edge type breakdown
     edge_types_added = Counter(rel for _, _, rel in added_edge_ids)
     edge_types_removed = Counter(rel for _, _, rel in removed_edge_ids)
 
     # God-node rank changes (top-20 only)
-    old_ranks = {nid: rank for rank, (nid, _) in enumerate(
-        sorted(G_old.degree(), key=lambda x: x[1], reverse=True)[:20]
-    )}
-    new_ranks = {nid: rank for rank, (nid, _) in enumerate(
-        sorted(G_new.degree(), key=lambda x: x[1], reverse=True)[:20]
-    )}
+    old_ranks = {
+        nid: rank
+        for rank, (nid, _) in enumerate(
+            sorted(G_old.degree(), key=lambda x: x[1], reverse=True)[:20]
+        )
+    }
+    new_ranks = {
+        nid: rank
+        for rank, (nid, _) in enumerate(
+            sorted(G_new.degree(), key=lambda x: x[1], reverse=True)[:20]
+        )
+    }
     rank_changes = []
     for nid in old_ranks:
         if nid in new_ranks:
             delta = old_ranks[nid] - new_ranks[nid]
             if delta != 0:
-                rank_changes.append({
-                    "id": str(nid),
-                    "label": str(G_new.nodes[nid].get("label", nid))
-                              if G_new.has_node(nid) else str(nid),
-                    "old_rank": old_ranks[nid] + 1,
-                    "new_rank": new_ranks[nid] + 1,
-                    "rank_delta": delta,
-                })
+                rank_changes.append(
+                    {
+                        "id": str(nid),
+                        "label": str(G_new.nodes[nid].get("label", nid))
+                        if G_new.has_node(nid)
+                        else str(nid),
+                        "old_rank": old_ranks[nid] + 1,
+                        "new_rank": new_ranks[nid] + 1,
+                        "rank_delta": delta,
+                    }
+                )
     rank_changes.sort(key=lambda x: abs(x["rank_delta"]), reverse=True)
 
     # Contradictions
     def _count_contradictions(G: nx.Graph) -> int:
-        return sum(
-            1 for _, _, d in G.edges(data=True)
-            if d.get("relation") == "CONTRADICTS"
-        ) + sum(1 for _, d in G.nodes(data=True) if d.get("contradiction"))
+        return sum(1 for _, _, d in G.edges(data=True) if d.get("relation") == "CONTRADICTS") + sum(
+            1 for _, d in G.nodes(data=True) if d.get("contradiction")
+        )
 
     contradictions_old = _count_contradictions(G_old)
     contradictions_new = _count_contradictions(G_new)
@@ -276,13 +309,15 @@ def diff_graphs(
     for u, v, data in G_old.edges(data=True):
         if data.get("relation") in _CAUSAL_RELATIONS:
             if u in set(removed_nodes) or v in set(removed_nodes):
-                orphaned_chains.append({
-                    "source": str(u),
-                    "target": str(v),
-                    "source_label": str(G_old.nodes[u].get("label", u)),
-                    "target_label": str(G_old.nodes[v].get("label", v)),
-                    "relation": str(data["relation"]),
-                })
+                orphaned_chains.append(
+                    {
+                        "source": str(u),
+                        "target": str(v),
+                        "source_label": str(G_old.nodes[u].get("label", u)),
+                        "target_label": str(G_old.nodes[v].get("label", v)),
+                        "relation": str(data["relation"]),
+                    }
+                )
 
     # Communities split/merged (heuristic via nodes' community attribute)
     community_changes = _detect_community_changes(G_old, G_new)
@@ -313,13 +348,15 @@ def diff_graphs(
     ]
 
     # Overall severity = max across all change categories
-    overall_severity = _aggregate_severity([
-        *(n["severity"] for n in added_with_severity),
-        *(n["severity"] for n in removed_with_severity),
-        "HIGH" if orphaned_chains else "INFO",
-        "MEDIUM" if contradictions_new > contradictions_old else "INFO",
-        "LOW" if rank_changes else "INFO",
-    ])
+    overall_severity = _aggregate_severity(
+        [
+            *(n["severity"] for n in added_with_severity),
+            *(n["severity"] for n in removed_with_severity),
+            "HIGH" if orphaned_chains else "INFO",
+            "MEDIUM" if contradictions_new > contradictions_old else "INFO",
+            "LOW" if rank_changes else "INFO",
+        ]
+    )
 
     return {
         "_schema": "graphify-plus-diff-1.1",
@@ -355,6 +392,7 @@ def diff_graphs(
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _detect_community_changes(G_old: nx.Graph, G_new: nx.Graph) -> dict:
     """Crude detection of community split/merge events."""
     old_communities: dict[Any, set] = {}
@@ -380,6 +418,7 @@ def _compute_health_delta(
     new_report: dict | Path | str | None,
 ) -> dict | None:
     """Extract health-score delta from two report.json files/dicts."""
+
     def _load(report: dict | Path | str | None) -> dict | None:
         if report is None:
             return None
@@ -414,6 +453,7 @@ def _compute_health_delta(
 # Renderers
 # ---------------------------------------------------------------------------
 
+
 def _signed(n: int) -> str:
     return f"+{n}" if n > 0 else str(n)
 
@@ -421,10 +461,10 @@ def _signed(n: int) -> str:
 def _severity_emoji(sev: SeverityStr) -> str:
     return {
         "CRITICAL": "[CRITICAL]",
-        "HIGH":     "[HIGH]",
-        "MEDIUM":   "[MEDIUM]",
-        "LOW":      "[LOW]",
-        "INFO":     "[INFO]",
+        "HIGH": "[HIGH]",
+        "MEDIUM": "[MEDIUM]",
+        "LOW": "[LOW]",
+        "INFO": "[INFO]",
     }.get(sev, "")
 
 
@@ -449,8 +489,8 @@ def format_pr_comment(diff: dict, max_items: int = 5) -> str:
         delta = health["delta"]
         emoji = "+" if delta > 0 else ""
         lines.append(
-            f"**Health score:** {health['old_score']} ({health.get('old_grade','?')}) "
-            f"-> {health['new_score']} ({health.get('new_grade','?')}) "
+            f"**Health score:** {health['old_score']} ({health.get('old_grade', '?')}) "
+            f"-> {health['new_score']} ({health.get('new_grade', '?')}) "
             f"({emoji}{delta:+d})"
         )
         lines.append("")
@@ -465,13 +505,9 @@ def format_pr_comment(diff: dict, max_items: int = 5) -> str:
         lines.append("")
 
     if diff.get("orphaned_causal_chains"):
-        lines.append(
-            f"### {len(diff['orphaned_causal_chains'])} causal chain(s) orphaned"
-        )
+        lines.append(f"### {len(diff['orphaned_causal_chains'])} causal chain(s) orphaned")
         for c in diff["orphaned_causal_chains"][:max_items]:
-            lines.append(
-                f"- `{c['source_label']}` -[{c['relation']}]-> `{c['target_label']}`"
-            )
+            lines.append(f"- `{c['source_label']}` -[{c['relation']}]-> `{c['target_label']}`")
         lines.append("")
 
     if diff.get("nodes_added"):
@@ -486,9 +522,7 @@ def format_pr_comment(diff: dict, max_items: int = 5) -> str:
         lines.append(f"### - {len(diff['nodes_removed'])} node(s) removed")
         for n in diff["nodes_removed"][:max_items]:
             sev_str = _severity_emoji(n["severity"])
-            lines.append(
-                f"- `{n['label']}` (was {n['had_degree']} deg) {sev_str}"
-            )
+            lines.append(f"- `{n['label']}` (was {n['had_degree']} deg) {sev_str}")
         if len(diff["nodes_removed"]) > max_items:
             lines.append(f"- _... and {len(diff['nodes_removed']) - max_items} more_")
         lines.append("")

--- a/tests/fixtures/sample_repo/backend/api.py
+++ b/tests/fixtures/sample_repo/backend/api.py
@@ -1,11 +1,14 @@
 """HTTP API for billing — fixture only."""
+
 from __future__ import annotations
 
 from .billing.invoice import Invoice, LineItem, make_invoice
 
 
 def post_invoice(customer_id: str, raw_items: list[dict]) -> dict:
-    items = [LineItem(sku=r["sku"], qty=int(r["qty"]),
-                      unit_price=float(r["unit_price"])) for r in raw_items]
+    items = [
+        LineItem(sku=r["sku"], qty=int(r["qty"]), unit_price=float(r["unit_price"]))
+        for r in raw_items
+    ]
     inv: Invoice = make_invoice(customer_id, items)
     return {"customer_id": customer_id, "total": inv.total()}

--- a/tests/fixtures/sample_repo/backend/billing/invoice.py
+++ b/tests/fixtures/sample_repo/backend/billing/invoice.py
@@ -1,4 +1,5 @@
 """Invoice domain model — tests/fixtures/sample_repo backend service."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -8,6 +9,7 @@ from typing import Iterable
 @dataclass
 class LineItem:
     """One line on an invoice."""
+
     sku: str
     qty: int
     unit_price: float

--- a/tests/interface/test_privacy.py
+++ b/tests/interface/test_privacy.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from graphify_plus.interface.privacy import redact, redact_dict
+
+
+def test_email():
+    assert redact("hi alice@example.com bye") == "hi <EMAIL> bye"
+
+
+def test_jwt():
+    tok = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NSJ9.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+    assert "<JWT>" in redact(f"Authorization: Bearer {tok}")
+
+
+def test_apikey_aws():
+    assert redact("AKIAIOSFODNN7EXAMPLE in logs") == "<APIKEY> in logs"
+
+
+def test_apikey_github_pat():
+    assert redact("ghp_aBcDeF1234567890abcdef1234567890abcd") == "<APIKEY>"
+
+
+def test_hex_long():
+    h = "abcdef0123456789abcdef0123456789abcdef0123456789"
+    assert redact(h) == "<HEX>"
+
+
+def test_phone_uk_redacted():
+    assert "<PHONE>" in redact("call +44 20 7946 0958 today")
+
+
+def test_short_digits_not_redacted_as_phone():
+    assert redact("123") == "123"
+
+
+def test_idempotent():
+    s = "alice@x.com and AKIA1234567890ABCDEF"
+    once = redact(s)
+    twice = redact(once)
+    assert once == twice
+
+
+def test_redact_dict_recursive():
+    d = {"who": "alice@x.com", "nested": {"key": "AKIAIOSFODNN7EXAMPLE"}}
+    out = redact_dict(d)
+    assert out["who"] == "<EMAIL>"
+    assert out["nested"]["key"] == "<APIKEY>"
+
+
+@given(s=st.text(min_size=0, max_size=100))
+def test_property_idempotent_under_random_input(s):
+    once = redact(s)
+    twice = redact(once)
+    assert once == twice

--- a/tests/query/test_enrichment.py
+++ b/tests/query/test_enrichment.py
@@ -1,0 +1,249 @@
+"""Phase 8 enrichment tests: git, telemetry, lockfile, blast-radius."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import networkx as nx
+
+from graphify_plus.core import cas
+from graphify_plus.core.ingest import ingest
+from graphify_plus.core.skeletonizer import skeletonize_all
+from graphify_plus.core.symbol_graph import build as build_graph
+from graphify_plus.query.blast_radius import trace as blast_trace
+from graphify_plus.query.git_silo import enrich_graph, parse_log
+from graphify_plus.query.lockfile import (
+    attach_to_graph,
+    parse_npm,
+    parse_poetry_lock,
+    parse_requirements_txt,
+)
+from graphify_plus.query.telemetry import aggregate
+from graphify_plus.query.telemetry import attach_to_graph as attach_telemetry
+from graphify_plus.runtime.store import Store, cache_path
+
+FIXTURE = Path(__file__).resolve().parents[1] / "fixtures" / "sample_repo"
+
+
+def _seed(tmp_path: Path) -> Path:
+    target = tmp_path / "repo"
+    shutil.copytree(FIXTURE, target)
+    res = ingest(target, parallel=False)
+    skel = skeletonize_all(res.symbols)
+    s = Store(cache_path(target))
+    try:
+        s.replace_all(res.symbols, res.edges)
+        for sid, body in skel.items():
+            h = cas.put(s, body)
+            s.link_skeleton(sid, h)
+    finally:
+        s.close()
+    return target
+
+
+# ---- git_silo ------------------------------------------------------------
+
+
+def test_parse_log_extracts_per_file_counts():
+    sample = (
+        "GP_COMMIT abc123\t2026-01-01T10:00:00+00:00\tAlice\n"
+        "1\t0\tsrc/a.py\n"
+        "2\t0\tsrc/b.py\n"
+        "GP_COMMIT def456\t2026-02-01T10:00:00+00:00\tBob\n"
+        "5\t1\tsrc/a.py\n"
+    )
+    stats = parse_log(sample)
+    assert stats["src/a.py"].commit_count == 2
+    assert stats["src/b.py"].commit_count == 1
+    assert stats["src/a.py"].last_touch_unix > stats["src/b.py"].last_touch_unix
+
+
+def test_enrich_graph_attaches_volatility_and_age():
+    G: nx.MultiDiGraph = nx.MultiDiGraph()
+    G.add_node("a", path="src/a.py", kind="function", in_degree=10)
+    G.add_node("b", path="src/b.py", kind="function")
+    sample = (
+        "GP_COMMIT 1\t2026-01-01T10:00:00+00:00\tA\n"
+        "1\t0\tsrc/a.py\n"
+        "GP_COMMIT 2\t2026-02-01T10:00:00+00:00\tA\n"
+        "1\t0\tsrc/a.py\n"
+        "GP_COMMIT 3\t2026-03-01T10:00:00+00:00\tA\n"
+        "1\t0\tsrc/a.py\n"
+        "GP_COMMIT 4\t2026-01-01T10:00:00+00:00\tA\n"
+        "1\t0\tsrc/b.py\n"
+    )
+    stats = parse_log(sample)
+    summary = enrich_graph(G, stats)
+    assert summary["files_enriched"] == 2
+    assert "volatility" in G.nodes["a"]
+    assert G.nodes["a"]["volatility"] >= G.nodes["b"]["volatility"]
+
+
+# ---- telemetry -----------------------------------------------------------
+
+
+def test_telemetry_aggregate_redacts_attrs():
+    lines = [
+        json.dumps(
+            {
+                "name": "invoice.Invoice.total",
+                "attributes": {"user_email": "alice@example.com", "tax_rate": 0.2},
+            }
+        ),
+        json.dumps(
+            {
+                "name": "invoice.Invoice.total",
+                "attributes": {"user_email": "bob@example.com", "tax_rate": None},
+            }
+        ),
+    ]
+    shapes = aggregate(lines)
+    assert "invoice.Invoice.total" in shapes
+    sh = shapes["invoice.Invoice.total"]
+    assert sh.sample_count == 2
+    assert sh.keys["user_email"]["samples"] == 2
+    # Privacy filter ran: every user_email value would have been redacted
+    # to <EMAIL> before being type-classified.
+    types = sh.keys["user_email"]["types"]
+    assert "string" in types
+
+
+def test_telemetry_attach_to_graph(tmp_path: Path):
+    repo = _seed(tmp_path)
+    s = Store(cache_path(repo))
+    try:
+        G = build_graph(s.all_symbols(), s.all_edges())
+        shapes = aggregate(
+            [
+                json.dumps(
+                    {
+                        "name": "invoice.Invoice.total",
+                        "attributes": {"tax_rate": 0.2},
+                    }
+                )
+            ]
+        )
+        matched = attach_telemetry(G, shapes)
+    finally:
+        s.close()
+    assert matched >= 1
+    n = next(
+        attrs
+        for _, attrs in G.nodes(data=True)
+        if attrs.get("qualified_name") == "invoice.Invoice.total"
+    )
+    assert "data_shape" in n
+
+
+# ---- lockfile ------------------------------------------------------------
+
+
+def test_parse_requirements_txt(tmp_path: Path):
+    p = tmp_path / "requirements.txt"
+    p.write_text("fastapi==0.110.0\npydantic>=2.6\n# comment\nrich\n")
+    deps = parse_requirements_txt(p)
+    names = {d.package for d in deps}
+    assert {"fastapi", "pydantic", "rich"} <= names
+
+
+def test_parse_npm(tmp_path: Path):
+    p = tmp_path / "package-lock.json"
+    p.write_text(
+        json.dumps(
+            {
+                "packages": {
+                    "": {"name": "myapp"},
+                    "node_modules/react": {"version": "18.2.0"},
+                    "node_modules/@types/node": {"version": "20.0.0"},
+                }
+            }
+        )
+    )
+    deps = parse_npm(p)
+    names = {d.package for d in deps}
+    assert "react" in names
+    assert "@types/node" in names
+
+
+def test_parse_poetry_lock(tmp_path: Path):
+    p = tmp_path / "poetry.lock"
+    p.write_text(
+        '[[package]]\nname = "fastapi"\nversion = "0.110.0"\n'
+        '[[package]]\nname = "pydantic"\nversion = "2.6"\n'
+    )
+    deps = parse_poetry_lock(p)
+    names = {d.package for d in deps}
+    assert "fastapi" in names and "pydantic" in names
+
+
+def test_lockfile_attaches_dependency_nodes(tmp_path: Path):
+    repo = _seed(tmp_path)
+    (repo / "requirements.txt").write_text("fastapi==0.110.0\nlodash==4.17.21\n")
+    s = Store(cache_path(repo))
+    try:
+        G = build_graph(s.all_symbols(), s.all_edges())
+        summary = attach_to_graph(repo, G)
+    finally:
+        s.close()
+    assert summary["packages"] == 2
+    deps = [a for _, a in G.nodes(data=True) if a.get("kind") == "dependency"]
+    assert {d["name"] for d in deps} == {"fastapi", "lodash"}
+
+
+# ---- blast-radius --------------------------------------------------------
+
+
+def test_blast_radius_unknown_package_returns_empty(tmp_path: Path):
+    repo = _seed(tmp_path)
+    s = Store(cache_path(repo))
+    try:
+        G = build_graph(s.all_symbols(), s.all_edges())
+        report = blast_trace(G, "nonexistent")
+    finally:
+        s.close()
+    assert report.hits == []
+    assert "No dependency node" in report.suggestion
+
+
+def test_blast_radius_traces_in_repo_dependents(tmp_path: Path):
+    repo = _seed(tmp_path)
+    (repo / "requirements.txt").write_text("fastapi==0.110.0\n")
+    s = Store(cache_path(repo))
+    try:
+        G = build_graph(s.all_symbols(), s.all_edges())
+        attach_to_graph(repo, G)
+        # Synthesise a transitive 'imports' edge: a real symbol → fastapi dep.
+        from graphify_plus.core.adapters import make_symbol_id
+
+        fastapi_id = make_symbol_id("dep::pypi", "fastapi")
+        sym = next(x for x in s.all_symbols() if x["qualified_name"] == "invoice.Invoice")
+        G.add_edge(sym["id"], fastapi_id, kind="imports")
+        report = blast_trace(G, "fastapi")
+    finally:
+        s.close()
+    assert any(h.qualified_name == "invoice.Invoice" for h in report.hits)
+
+
+# ---- repo-aware enrich CLI smoke ----------------------------------------
+
+
+def test_enrich_lockfile_persists_via_cli(tmp_path: Path):
+    repo = _seed(tmp_path)
+    (repo / "requirements.txt").write_text("fastapi==0.110.0\n")
+    res = subprocess.run(
+        ["python", "-m", "graphify_plus", "enrich", "--repo", str(repo), "lockfile"],
+        capture_output=True,
+        check=False,
+    )
+    assert res.returncode == 0, res.stderr.decode()
+    s = Store(cache_path(repo))
+    try:
+        kinds = {
+            a.get("kind") for _, a in build_graph(s.all_symbols(), s.all_edges()).nodes(data=True)
+        }
+    finally:
+        s.close()
+    assert "dependency" in kinds

--- a/tests/test_audit_production.py
+++ b/tests/test_audit_production.py
@@ -1,4 +1,5 @@
 """Production-grade test suite for graphify_plus.audit."""
+
 import json
 import random
 from pathlib import Path
@@ -18,41 +19,57 @@ def _make_basic_graph():
     G.add_edge("auth_service", "user_model", relation="uses", confidence="EXTRACTED")
     G.add_edge("login_fn", "auth_service", relation="calls", confidence="EXTRACTED")
     G.add_edge("login_fn", "db_write", relation="modifies", confidence="EXTRACTED")
-    G.add_edge("auth_service", "token_validator", relation="delegates_to",
-               confidence="INFERRED", confidence_score=0.78)
-    G.add_edge("token_validator", "audit_log", relation="writes_to",
-               confidence="INFERRED", confidence_score=0.65)
-    G.add_edge("auth_service", "config", relation="uses",
-               confidence="INFERRED", confidence_score=0.50)
+    G.add_edge(
+        "auth_service",
+        "token_validator",
+        relation="delegates_to",
+        confidence="INFERRED",
+        confidence_score=0.78,
+    )
+    G.add_edge(
+        "token_validator",
+        "audit_log",
+        relation="writes_to",
+        confidence="INFERRED",
+        confidence_score=0.65,
+    )
+    G.add_edge(
+        "auth_service", "config", relation="uses", confidence="INFERRED", confidence_score=0.50
+    )
     return G
 
 
 # ─── Probe 1: edge deletion stability ───────────────────────────────────────
 
+
 class TestEdgeDeletionStability:
     def test_basic_run(self):
         from graphify_plus.audit.probe import probe_edge_deletion_stability
+
         G = _make_basic_graph()
         r = probe_edge_deletion_stability(G, iterations=3, seed=1)
         assert r["skipped"] is False
-        assert r["stability_grade"] in ("A","B","C","D","F")
+        assert r["stability_grade"] in ("A", "B", "C", "D", "F")
         assert 0 <= r["avg_overlap"] <= 1
 
     def test_empty_graph(self):
         from graphify_plus.audit.probe import probe_edge_deletion_stability
+
         r = probe_edge_deletion_stability(nx.Graph(), iterations=1)
         assert r["skipped"] is True
 
     def test_no_community_attr(self):
         from graphify_plus.audit.probe import probe_edge_deletion_stability
+
         G = nx.Graph()
-        G.add_edges_from([("a","b"),("b","c")])
+        G.add_edges_from([("a", "b"), ("b", "c")])
         r = probe_edge_deletion_stability(G)
         assert r["skipped"] is True
         assert "community" in r["reason"].lower()
 
     def test_no_edges(self):
         from graphify_plus.audit.probe import probe_edge_deletion_stability
+
         G = nx.Graph()
         G.add_node("a", community=0)
         r = probe_edge_deletion_stability(G)
@@ -60,6 +77,7 @@ class TestEdgeDeletionStability:
 
     def test_invalid_deletion_rate(self):
         from graphify_plus.audit.probe import probe_edge_deletion_stability
+
         G = _make_basic_graph()
         for bad_rate in (0.0, 1.0, -0.5, 1.5, 2.0):
             r = probe_edge_deletion_stability(G, deletion_rate=bad_rate)
@@ -67,12 +85,14 @@ class TestEdgeDeletionStability:
 
     def test_invalid_iterations(self):
         from graphify_plus.audit.probe import probe_edge_deletion_stability
+
         G = _make_basic_graph()
         r = probe_edge_deletion_stability(G, iterations=0)
         assert r["skipped"] is True
 
     def test_deterministic_with_same_seed(self):
         from graphify_plus.audit.probe import probe_edge_deletion_stability
+
         G = _make_basic_graph()
         r1 = probe_edge_deletion_stability(G, seed=42, iterations=3)
         r2 = probe_edge_deletion_stability(G, seed=42, iterations=3)
@@ -82,96 +102,110 @@ class TestEdgeDeletionStability:
 
 # ─── Probe 2: confidence drift ──────────────────────────────────────────────
 
+
 class TestConfidenceDrift:
     def test_basic_run(self):
         from graphify_plus.audit.probe import probe_confidence_drift
+
         G = _make_basic_graph()
         r = probe_confidence_drift(G)
         assert r["skipped"] is False
         assert r["inferred_edge_count"] == 3
-        assert r["drift_grade"] in ("A","B","C","D","F")
+        assert r["drift_grade"] in ("A", "B", "C", "D", "F")
 
     def test_empty_graph(self):
         from graphify_plus.audit.probe import probe_confidence_drift
+
         r = probe_confidence_drift(nx.Graph())
         assert r["skipped"] is True
 
     def test_too_few_inferred_edges(self):
         from graphify_plus.audit.probe import probe_confidence_drift
+
         G = nx.Graph()
-        G.add_node("a"); G.add_node("b")
-        G.add_edge("a","b", confidence="INFERRED", confidence_score=0.7)
+        G.add_node("a")
+        G.add_node("b")
+        G.add_edge("a", "b", confidence="INFERRED", confidence_score=0.7)
         r = probe_confidence_drift(G)
         assert r["skipped"] is True
 
     def test_invalid_score_values_ignored(self):
         from graphify_plus.audit.probe import probe_confidence_drift
+
         G = nx.Graph()
         for i in range(5):
             G.add_node(f"n{i}")
         # 3 valid scores + 2 invalid (out of range, wrong type)
-        G.add_edge("n0","n1", confidence="INFERRED", confidence_score=0.7)
-        G.add_edge("n1","n2", confidence="INFERRED", confidence_score=0.6)
-        G.add_edge("n2","n3", confidence="INFERRED", confidence_score=0.8)
-        G.add_edge("n3","n4", confidence="INFERRED", confidence_score=2.0)  # invalid
-        G.add_edge("n0","n2", confidence="INFERRED", confidence_score="0.5")  # invalid type
+        G.add_edge("n0", "n1", confidence="INFERRED", confidence_score=0.7)
+        G.add_edge("n1", "n2", confidence="INFERRED", confidence_score=0.6)
+        G.add_edge("n2", "n3", confidence="INFERRED", confidence_score=0.8)
+        G.add_edge("n3", "n4", confidence="INFERRED", confidence_score=2.0)  # invalid
+        G.add_edge("n0", "n2", confidence="INFERRED", confidence_score="0.5")  # invalid type
         r = probe_confidence_drift(G)
         assert r["inferred_edge_count"] == 3
 
 
 # ─── Probe 3: rename sensitivity ────────────────────────────────────────────
 
+
 class TestRenameSensitivity:
     def test_basic_run(self):
         from graphify_plus.audit.probe import probe_rename_sensitivity
+
         G = _make_basic_graph()
         r = probe_rename_sensitivity(G)
         assert r["skipped"] is False
-        assert r["rename_grade"] in ("A","B","C","D","F")
+        assert r["rename_grade"] in ("A", "B", "C", "D", "F")
 
     def test_detects_self_referencing_edge(self):
         from graphify_plus.audit.probe import probe_rename_sensitivity
+
         G = nx.Graph()
         G.add_node("auth", label="AuthService")
         G.add_node("user", label="User")
         G.add_node("log", label="Log")
-        G.add_edge("auth","user", evidence="AuthService delegates to User")
-        G.add_edge("auth","log", description="AuthService writes to Log")
+        G.add_edge("auth", "user", evidence="AuthService delegates to User")
+        G.add_edge("auth", "log", description="AuthService writes to Log")
         r = probe_rename_sensitivity(G)
         assert any(f["label"] == "AuthService" for f in r["fragile_nodes"])
 
     def test_short_labels_ignored(self):
         from graphify_plus.audit.probe import probe_rename_sensitivity
+
         G = nx.Graph()
         G.add_node("a", label="x")  # label too short
         G.add_node("b", label="y")
-        G.add_edge("a","b", evidence="x calls y")
+        G.add_edge("a", "b", evidence="x calls y")
         r = probe_rename_sensitivity(G)
         assert r["fragile_nodes"] == []
 
     def test_directed_graph(self):
         from graphify_plus.audit.probe import probe_rename_sensitivity
+
         G = nx.DiGraph()
         G.add_node("auth", label="AuthService")
         G.add_node("db", label="Database")
-        G.add_edge("auth","db", evidence="AuthService persists to db")
+        G.add_edge("auth", "db", evidence="AuthService persists to db")
         r = probe_rename_sensitivity(G)
         assert any(f["label"] == "AuthService" for f in r["fragile_nodes"])
 
 
 # ─── Probe 4: structural fragility ──────────────────────────────────────────
 
+
 class TestStructuralFragility:
     def test_finds_articulation_point(self):
         from graphify_plus.audit.probe import probe_structural_fragility
+
         G = nx.Graph()
-        G.add_edges_from([("a","cut"),("b","cut"),("cut","c"),("c","d"),("d","e")])
+        G.add_edges_from([("a", "cut"), ("b", "cut"), ("cut", "c"), ("c", "d"), ("d", "e")])
         r = probe_structural_fragility(G)
         ids = {p["id"] for p in r["articulation_points"]}
         assert "cut" in ids
 
     def test_complete_graph_no_articulation(self):
         from graphify_plus.audit.probe import probe_structural_fragility
+
         G = nx.complete_graph(5)
         r = probe_structural_fragility(G)
         assert r["articulation_count"] == 0
@@ -179,33 +213,38 @@ class TestStructuralFragility:
 
     def test_disconnected_graph(self):
         from graphify_plus.audit.probe import probe_structural_fragility
+
         G = nx.Graph()
-        G.add_edges_from([("a","b"),("c","d")])  # disconnected
+        G.add_edges_from([("a", "b"), ("c", "d")])  # disconnected
         r = probe_structural_fragility(G)
         # Should not crash, should restrict to largest CC
         assert "skipped" in r
 
     def test_directed_handled(self):
         from graphify_plus.audit.probe import probe_structural_fragility
+
         G = nx.DiGraph()
-        G.add_edges_from([("a","b"),("b","c"),("c","d")])
+        G.add_edges_from([("a", "b"), ("b", "c"), ("c", "d")])
         r = probe_structural_fragility(G)
         assert "skipped" in r
 
     def test_multigraph_handled(self):
         from graphify_plus.audit.probe import probe_structural_fragility
+
         G = nx.MultiGraph()
-        G.add_edges_from([("a","b"),("a","b"),("b","c"),("c","d")])
+        G.add_edges_from([("a", "b"), ("a", "b"), ("b", "c"), ("c", "d")])
         r = probe_structural_fragility(G)
         assert "skipped" in r
 
     def test_empty_graph(self):
         from graphify_plus.audit.probe import probe_structural_fragility
+
         r = probe_structural_fragility(nx.Graph())
         assert r["skipped"] is True
 
     def test_single_node(self):
         from graphify_plus.audit.probe import probe_structural_fragility
+
         G = nx.Graph()
         G.add_node("a")
         r = probe_structural_fragility(G)
@@ -214,34 +253,41 @@ class TestStructuralFragility:
 
 # ─── Probe 5: lonely INFERRED edges ─────────────────────────────────────────
 
+
 class TestLonelyInferredEdges:
     def test_basic_run(self):
         from graphify_plus.audit.probe import probe_lonely_inferred_edges
+
         G = _make_basic_graph()
         r = probe_lonely_inferred_edges(G)
         assert r["skipped"] is False
 
     def test_high_confidence_skipped(self):
         from graphify_plus.audit.probe import probe_lonely_inferred_edges
+
         G = nx.Graph()
-        G.add_node("a"); G.add_node("b")
-        G.add_edge("a","b", confidence="INFERRED", confidence_score=0.95)
+        G.add_node("a")
+        G.add_node("b")
+        G.add_edge("a", "b", confidence="INFERRED", confidence_score=0.95)
         r = probe_lonely_inferred_edges(G, high_confidence_cutoff=0.85)
         assert r["lonely_count"] == 0
 
     def test_low_confidence_with_no_shared_neighbour(self):
         from graphify_plus.audit.probe import probe_lonely_inferred_edges
+
         G = nx.Graph()
-        G.add_node("a"); G.add_node("b")
-        G.add_edge("a","b", confidence="INFERRED", confidence_score=0.50)
+        G.add_node("a")
+        G.add_node("b")
+        G.add_edge("a", "b", confidence="INFERRED", confidence_score=0.50)
         r = probe_lonely_inferred_edges(G)
         assert r["lonely_count"] == 1
 
     def test_with_shared_neighbour_not_lonely(self):
         from graphify_plus.audit.probe import probe_lonely_inferred_edges
+
         G = nx.Graph()
-        G.add_edges_from([("a","x"),("b","x")])
-        G.add_edge("a","b", confidence="INFERRED", confidence_score=0.50)
+        G.add_edges_from([("a", "x"), ("b", "x")])
+        G.add_edge("a", "b", confidence="INFERRED", confidence_score=0.50)
         r = probe_lonely_inferred_edges(G)
         # a-b has shared neighbour x -> not lonely
         assert r["lonely_count"] == 0
@@ -249,44 +295,51 @@ class TestLonelyInferredEdges:
 
 # ─── Probe 6: modularity quality ────────────────────────────────────────────
 
+
 class TestModularityQuality:
     def test_basic_run(self):
         from graphify_plus.audit.probe import probe_modularity_quality
+
         G = _make_basic_graph()
         r = probe_modularity_quality(G)
         assert r["skipped"] is False
         assert -0.5 <= r["modularity_Q"] <= 1.0
-        assert r["modularity_grade"] in ("A","B","C","D","F")
+        assert r["modularity_grade"] in ("A", "B", "C", "D", "F")
 
     def test_no_communities(self):
         from graphify_plus.audit.probe import probe_modularity_quality
+
         G = nx.Graph()
-        G.add_edges_from([("a","b"),("b","c")])
+        G.add_edges_from([("a", "b"), ("b", "c")])
         r = probe_modularity_quality(G)
         assert r["skipped"] is True
 
     def test_single_community(self):
         from graphify_plus.audit.probe import probe_modularity_quality
+
         G = nx.Graph()
         G.add_node("a", community=0)
         G.add_node("b", community=0)
-        G.add_edge("a","b")
+        G.add_edge("a", "b")
         r = probe_modularity_quality(G)
         assert r["skipped"] is True
 
 
 # ─── Probe 7: centrality drift ──────────────────────────────────────────────
 
+
 class TestCentralityDrift:
     def test_basic_run(self):
         from graphify_plus.audit.probe import probe_centrality_drift
+
         G = _make_basic_graph()
         r = probe_centrality_drift(G)
         assert r["skipped"] is False
-        assert r["centrality_grade"] in ("A","B","C","D","F","N/A")
+        assert r["centrality_grade"] in ("A", "B", "C", "D", "F", "N/A")
 
     def test_no_edges(self):
         from graphify_plus.audit.probe import probe_centrality_drift
+
         G = nx.Graph()
         G.add_node("a")
         r = probe_centrality_drift(G)
@@ -294,33 +347,42 @@ class TestCentralityDrift:
 
     def test_empty_graph(self):
         from graphify_plus.audit.probe import probe_centrality_drift
+
         r = probe_centrality_drift(nx.Graph())
         assert r["skipped"] is True
 
 
 # ─── Audit aggregation ──────────────────────────────────────────────────────
 
+
 class TestRunAudit:
     def test_full_run(self):
         from graphify_plus.audit.probe import run_audit
+
         G = _make_basic_graph()
         r = run_audit(G, iterations=3, seed=1)
         for probe in (
-            "edge_deletion_stability","confidence_drift","rename_sensitivity",
-            "structural_fragility","lonely_inferred_edges","modularity_quality",
+            "edge_deletion_stability",
+            "confidence_drift",
+            "rename_sensitivity",
+            "structural_fragility",
+            "lonely_inferred_edges",
+            "modularity_quality",
             "centrality_drift",
         ):
             assert probe in r
-        assert r["overall_grade"] in ("A","B","C","D","F","N/A")
+        assert r["overall_grade"] in ("A", "B", "C", "D", "F", "N/A")
 
     def test_empty_graph_handled_gracefully(self):
         from graphify_plus.audit.probe import run_audit
+
         r = run_audit(nx.Graph())
         assert r["skipped"] is True
         assert r["overall_grade"] == "N/A"
 
     def test_only_subset_of_probes(self):
         from graphify_plus.audit.probe import run_audit
+
         G = _make_basic_graph()
         r = run_audit(G, only=["confidence_drift"])
         assert "confidence_drift" in r
@@ -328,42 +390,50 @@ class TestRunAudit:
 
     def test_skip_expensive(self):
         from graphify_plus.audit.probe import run_audit
+
         G = _make_basic_graph()
         r = run_audit(G, skip_expensive=True)
         assert "centrality_drift" not in r
 
     def test_invalid_input_returns_safe_dict(self):
         from graphify_plus.audit.probe import run_audit
+
         r = run_audit(None)
         assert r["skipped"] is True
         assert r["overall_grade"] == "N/A"
 
     def test_directed_graph(self):
         from graphify_plus.audit.probe import run_audit
+
         G = nx.DiGraph()
-        G.add_node("a", community=0); G.add_node("b", community=0); G.add_node("c", community=1)
-        G.add_edge("a","b", confidence="EXTRACTED")
-        G.add_edge("b","c", confidence="EXTRACTED")
+        G.add_node("a", community=0)
+        G.add_node("b", community=0)
+        G.add_node("c", community=1)
+        G.add_edge("a", "b", confidence="EXTRACTED")
+        G.add_edge("b", "c", confidence="EXTRACTED")
         r = run_audit(G)
         assert r["graph_size"]["directed"] is True
 
     def test_multigraph(self):
         from graphify_plus.audit.probe import run_audit
+
         G = nx.MultiGraph()
         for i in range(3):
             G.add_node(f"n{i}", community=i % 2)
-        G.add_edge("n0","n1", confidence="EXTRACTED")
-        G.add_edge("n0","n1", confidence="INFERRED", confidence_score=0.7)
-        G.add_edge("n1","n2", confidence="EXTRACTED")
+        G.add_edge("n0", "n1", confidence="EXTRACTED")
+        G.add_edge("n0", "n1", confidence="INFERRED", confidence_score=0.7)
+        G.add_edge("n1", "n2", confidence="EXTRACTED")
         r = run_audit(G, skip_expensive=True)
         assert r["graph_size"]["multigraph"] is True
 
 
 # ─── Format and threshold ───────────────────────────────────────────────────
 
+
 class TestFormatAndThreshold:
     def test_format_audit_report(self):
         from graphify_plus.audit.probe import run_audit, format_audit_report
+
         G = _make_basic_graph()
         r = run_audit(G)
         md = format_audit_report(r)
@@ -371,31 +441,37 @@ class TestFormatAndThreshold:
 
     def test_format_skipped_audit(self):
         from graphify_plus.audit.probe import run_audit, format_audit_report
+
         r = run_audit(nx.Graph())
         md = format_audit_report(r)
         assert "Skipped" in md
 
     def test_meets_threshold_pass(self):
         from graphify_plus.audit.probe import audit_meets_threshold
+
         assert audit_meets_threshold({"overall_grade": "A"}, "B") is True
         assert audit_meets_threshold({"overall_grade": "B"}, "B") is True
 
     def test_meets_threshold_fail(self):
         from graphify_plus.audit.probe import audit_meets_threshold
+
         assert audit_meets_threshold({"overall_grade": "D"}, "B") is False
 
     def test_meets_threshold_na_passes(self):
         from graphify_plus.audit.probe import audit_meets_threshold
+
         # N/A should not fail CI
         assert audit_meets_threshold({"overall_grade": "N/A"}, "A") is True
 
 
 # ─── CLI ────────────────────────────────────────────────────────────────────
 
+
 class TestAuditCLI:
     def test_loads_graph_and_runs(self, tmp_path, capsys):
         from graphify_plus.audit.cli import main
         from graphify_plus.report_json import save_enhanced_graph
+
         G = _make_basic_graph()
         save_enhanced_graph(G, tmp_path)
         rc = main([str(tmp_path / "graph_enhanced.json"), "--quiet"])
@@ -403,20 +479,25 @@ class TestAuditCLI:
 
     def test_cli_missing_file(self, tmp_path):
         from graphify_plus.audit.cli import main
+
         rc = main([str(tmp_path / "nonexistent.json"), "--quiet"])
         assert rc == 2
 
     def test_cli_json_output(self, tmp_path):
         from graphify_plus.audit.cli import main
         from graphify_plus.report_json import save_enhanced_graph
+
         G = _make_basic_graph()
         save_enhanced_graph(G, tmp_path)
         out_file = tmp_path / "audit.json"
-        rc = main([
-            str(tmp_path / "graph_enhanced.json"),
-            "--json-output", str(out_file),
-            "--quiet",
-        ])
+        rc = main(
+            [
+                str(tmp_path / "graph_enhanced.json"),
+                "--json-output",
+                str(out_file),
+                "--quiet",
+            ]
+        )
         assert rc == 0
         assert out_file.exists()
         data = json.loads(out_file.read_text())
@@ -425,30 +506,41 @@ class TestAuditCLI:
     def test_cli_fail_below_grade(self, tmp_path):
         from graphify_plus.audit.cli import main
         from graphify_plus.report_json import save_enhanced_graph
+
         # Create a graph that should fail high thresholds
         G = nx.Graph()
-        G.add_node("a", community=0); G.add_node("b", community=1)
+        G.add_node("a", community=0)
+        G.add_node("b", community=1)
         G.add_edge("a", "b", confidence="INFERRED", confidence_score=0.3)
         save_enhanced_graph(G, tmp_path)
-        rc = main([
-            str(tmp_path / "graph_enhanced.json"),
-            "--fail-below", "A", "--quiet",
-        ])
+        rc = main(
+            [
+                str(tmp_path / "graph_enhanced.json"),
+                "--fail-below",
+                "A",
+                "--quiet",
+            ]
+        )
         # May pass or fail depending on grade; just ensure no crash
         assert rc in (0, 1)
 
     def test_cli_only_filters_probes(self, tmp_path):
         from graphify_plus.audit.cli import main
         from graphify_plus.report_json import save_enhanced_graph
+
         G = _make_basic_graph()
         save_enhanced_graph(G, tmp_path)
         out_file = tmp_path / "audit.json"
-        rc = main([
-            str(tmp_path / "graph_enhanced.json"),
-            "--only", "confidence_drift",
-            "--json-output", str(out_file),
-            "--quiet",
-        ])
+        rc = main(
+            [
+                str(tmp_path / "graph_enhanced.json"),
+                "--only",
+                "confidence_drift",
+                "--json-output",
+                str(out_file),
+                "--quiet",
+            ]
+        )
         assert rc == 0
         data = json.loads(out_file.read_text())
         assert "confidence_drift" in data
@@ -457,30 +549,34 @@ class TestAuditCLI:
 
 # ─── Stress / edge cases ────────────────────────────────────────────────────
 
+
 class TestStressAndEdgeCases:
     def test_unicode_labels(self):
         from graphify_plus.audit.probe import run_audit
+
         G = nx.Graph()
         G.add_node("a", label="日本語サービス", community=0)
         G.add_node("b", label="مصادقة", community=0)
         G.add_node("c", label="Auth🔐", community=1)
-        G.add_edge("a","b", confidence="EXTRACTED")
-        G.add_edge("b","c", confidence="EXTRACTED")
+        G.add_edge("a", "b", confidence="EXTRACTED")
+        G.add_edge("b", "c", confidence="EXTRACTED")
         r = run_audit(G)
         assert "skipped" not in r or not r.get("skipped")
 
     def test_very_long_labels(self):
         from graphify_plus.audit.probe import probe_rename_sensitivity
+
         G = nx.Graph()
         long_label = "x" * 1000
         G.add_node("a", label=long_label)
         G.add_node("b", label="b")
-        G.add_edge("a","b", evidence=long_label[:500])
+        G.add_edge("a", "b", evidence=long_label[:500])
         # Should not crash
         probe_rename_sensitivity(G)
 
     def test_numeric_node_ids(self):
         from graphify_plus.audit.probe import run_audit
+
         G = nx.Graph()
         G.add_node(1, label="One", community=0)
         G.add_node(2, label="Two", community=1)
@@ -490,6 +586,7 @@ class TestStressAndEdgeCases:
 
     def test_serialisable_to_json(self):
         from graphify_plus.audit.probe import run_audit
+
         G = _make_basic_graph()
         r = run_audit(G)
         # Must be fully JSON-serialisable
@@ -499,6 +596,7 @@ class TestStressAndEdgeCases:
 
     def test_concurrent_runs_dont_share_state(self):
         from graphify_plus.audit.probe import run_audit
+
         G1 = _make_basic_graph()
         G2 = nx.Graph()
         G2.add_node("solo", community=0)

--- a/tests/test_diff_production.py
+++ b/tests/test_diff_production.py
@@ -1,4 +1,5 @@
 """Production-grade test suite for graphify_plus.review."""
+
 import json
 from pathlib import Path
 import networkx as nx
@@ -10,12 +11,22 @@ def _make_graph(extra_nodes=None, extra_edges=None):
     G.add_node("auth_service", label="AuthService", source_file="src/auth.py", community=0)
     G.add_node("user_model", label="UserModel", source_file="src/models.py", community=0)
     G.add_node("login_fn", label="login", source_file="src/auth.py", community=0)
-    G.add_node("rationale", label="OAuth2 reason", source_file="docs/SECURITY.md",
-               community=2, node_type="rationale_for")
+    G.add_node(
+        "rationale",
+        label="OAuth2 reason",
+        source_file="docs/SECURITY.md",
+        community=2,
+        node_type="rationale_for",
+    )
     G.add_edge("auth_service", "user_model", relation="uses", confidence="EXTRACTED")
     G.add_edge("login_fn", "auth_service", relation="calls", confidence="EXTRACTED")
-    G.add_edge("rationale", "auth_service", relation="caused_by",
-               confidence="INFERRED", confidence_score=0.78)
+    G.add_edge(
+        "rationale",
+        "auth_service",
+        relation="caused_by",
+        confidence="INFERRED",
+        confidence_score=0.78,
+    )
     if extra_nodes:
         for nid, attrs in extra_nodes.items():
             G.add_node(nid, **attrs)
@@ -30,17 +41,18 @@ def _save_graph(G, path):
     data = {
         "_directed": G.is_directed(),
         "nodes": [{"id": n, **G.nodes[n]} for n in G.nodes()],
-        "edges": [{"source": u, "target": v, **G.edges[u, v]}
-                  for u, v in G.edges()],
+        "edges": [{"source": u, "target": v, **G.edges[u, v]} for u, v in G.edges()],
     }
     Path(path).write_text(json.dumps(data, indent=2, default=str))
 
 
 # ─── Loading and validation ────────────────────────────────────────────────
 
+
 class TestLoading:
     def test_load_from_path(self, tmp_path):
         from graphify_plus.review.graph_diff import diff_graphs
+
         old = _make_graph()
         new = _make_graph()
         new.add_node("z", label="Z", source_file="z.py")
@@ -53,6 +65,7 @@ class TestLoading:
 
     def test_load_directly_from_graph(self):
         from graphify_plus.review.graph_diff import diff_graphs
+
         old = _make_graph()
         new = _make_graph()
         new.add_node("z", label="Z")
@@ -61,6 +74,7 @@ class TestLoading:
 
     def test_invalid_json_raises(self, tmp_path):
         from graphify_plus.review.graph_diff import diff_graphs
+
         bad = tmp_path / "bad.json"
         bad.write_text("not json at all {")
         good = tmp_path / "good.json"
@@ -70,6 +84,7 @@ class TestLoading:
 
     def test_missing_keys_raise(self, tmp_path):
         from graphify_plus.review.graph_diff import diff_graphs
+
         bad = tmp_path / "bad.json"
         bad.write_text('{"foo": "bar"}')
         good = tmp_path / "good.json"
@@ -79,6 +94,7 @@ class TestLoading:
 
     def test_missing_file_raises(self, tmp_path):
         from graphify_plus.review.graph_diff import diff_graphs
+
         good = tmp_path / "good.json"
         _save_graph(_make_graph(), good)
         with pytest.raises(FileNotFoundError):
@@ -87,9 +103,11 @@ class TestLoading:
 
 # ─── Severity classification ────────────────────────────────────────────────
 
+
 class TestSeverity:
     def test_critical_for_high_degree_node_removal(self):
         from graphify_plus.review.graph_diff import diff_graphs
+
         old = _make_graph()
         # Add a hub node with 10+ edges so its removal becomes critical
         for i in range(12):
@@ -104,6 +122,7 @@ class TestSeverity:
 
     def test_low_for_isolated_node_removal(self):
         from graphify_plus.review.graph_diff import diff_graphs
+
         old = _make_graph(extra_nodes={"isolated": {"label": "Isolated"}})
         new = _make_graph()  # no isolated node
         d = diff_graphs(old, new)
@@ -113,6 +132,7 @@ class TestSeverity:
 
     def test_node_with_causal_edge_is_critical(self):
         from graphify_plus.review.graph_diff import diff_graphs
+
         old = _make_graph()
         new = _make_graph()
         new.remove_node("rationale")
@@ -122,6 +142,7 @@ class TestSeverity:
 
     def test_overall_severity_is_max(self):
         from graphify_plus.review.graph_diff import diff_graphs
+
         old = _make_graph()
         new = _make_graph()
         new.remove_node("rationale")  # causes orphan + critical removal
@@ -131,9 +152,11 @@ class TestSeverity:
 
 # ─── Diff content ───────────────────────────────────────────────────────────
 
+
 class TestDiffContent:
     def test_node_addition(self):
         from graphify_plus.review.graph_diff import diff_graphs
+
         old = _make_graph()
         new = _make_graph(extra_nodes={"new_node": {"label": "New", "source_file": "new.py"}})
         d = diff_graphs(old, new)
@@ -142,6 +165,7 @@ class TestDiffContent:
 
     def test_node_removal(self):
         from graphify_plus.review.graph_diff import diff_graphs
+
         old = _make_graph()
         new = _make_graph()
         new.remove_node("login_fn")
@@ -150,6 +174,7 @@ class TestDiffContent:
 
     def test_edge_addition_count(self):
         from graphify_plus.review.graph_diff import diff_graphs
+
         old = _make_graph()
         new = _make_graph()
         new.add_edge("login_fn", "user_model", relation="uses", confidence="EXTRACTED")
@@ -158,6 +183,7 @@ class TestDiffContent:
 
     def test_edge_attribute_change_detected(self):
         from graphify_plus.review.graph_diff import diff_graphs
+
         old = _make_graph()
         new = _make_graph()
         new["auth_service"]["user_model"]["relation"] = "wraps"  # changed relation
@@ -171,6 +197,7 @@ class TestDiffContent:
 
     def test_orphaned_causal_chains_detected(self):
         from graphify_plus.review.graph_diff import diff_graphs
+
         old = _make_graph()
         new = _make_graph()
         new.remove_node("rationale")
@@ -179,6 +206,7 @@ class TestDiffContent:
 
     def test_god_node_rank_change(self):
         from graphify_plus.review.graph_diff import diff_graphs
+
         old = _make_graph()
         # Add many edges to make user_model a higher-rank god node in new
         new = _make_graph()
@@ -191,19 +219,21 @@ class TestDiffContent:
 
     def test_contradictions_delta(self):
         from graphify_plus.review.graph_diff import diff_graphs
+
         old = _make_graph()
         new = _make_graph()
-        new.add_edge("login_fn", "user_model",
-                     relation="CONTRADICTS", description="conflict")
+        new.add_edge("login_fn", "user_model", relation="CONTRADICTS", description="conflict")
         d = diff_graphs(old, new)
         assert d["contradictions"]["delta"] == 1
 
 
 # ─── Health delta ───────────────────────────────────────────────────────────
 
+
 class TestHealthDelta:
     def test_health_delta_present(self, tmp_path):
         from graphify_plus.review.graph_diff import diff_graphs
+
         old_report = {"health": {"score": 75, "grade": "B"}}
         new_report = {"health": {"score": 82, "grade": "B"}}
         old = _make_graph()
@@ -213,39 +243,43 @@ class TestHealthDelta:
 
     def test_health_delta_from_paths(self, tmp_path):
         from graphify_plus.review.graph_diff import diff_graphs
+
         old_rp = tmp_path / "old.json"
         new_rp = tmp_path / "new.json"
         old_rp.write_text(json.dumps({"health": {"score": 60, "grade": "C"}}))
         new_rp.write_text(json.dumps({"health": {"score": 85, "grade": "A"}}))
-        d = diff_graphs(_make_graph(), _make_graph(),
-                        old_report=old_rp, new_report=new_rp)
+        d = diff_graphs(_make_graph(), _make_graph(), old_report=old_rp, new_report=new_rp)
         assert d["health_delta"]["delta"] == 25
 
     def test_no_health_delta_without_reports(self):
         from graphify_plus.review.graph_diff import diff_graphs
+
         d = diff_graphs(_make_graph(), _make_graph())
         assert d["health_delta"] is None
 
     def test_malformed_report_doesnt_crash(self, tmp_path):
         from graphify_plus.review.graph_diff import diff_graphs
+
         bad_rp = tmp_path / "bad.json"
         bad_rp.write_text("garbage")
-        d = diff_graphs(_make_graph(), _make_graph(),
-                        old_report=bad_rp, new_report=bad_rp)
+        d = diff_graphs(_make_graph(), _make_graph(), old_report=bad_rp, new_report=bad_rp)
         assert d["health_delta"] is None
 
 
 # ─── Format ─────────────────────────────────────────────────────────────────
 
+
 class TestFormat:
     def test_pr_comment_basic(self):
         from graphify_plus.review.graph_diff import diff_graphs, format_pr_comment
+
         d = diff_graphs(_make_graph(), _make_graph())
         md = format_pr_comment(d)
         assert "Graph diff" in md
 
     def test_pr_comment_with_changes(self):
         from graphify_plus.review.graph_diff import diff_graphs, format_pr_comment
+
         old = _make_graph()
         new = _make_graph(extra_nodes={"new1": {"label": "New1"}})
         d = diff_graphs(old, new)
@@ -255,8 +289,10 @@ class TestFormat:
 
     def test_pr_comment_with_health_delta(self):
         from graphify_plus.review.graph_diff import diff_graphs, format_pr_comment
+
         d = diff_graphs(
-            _make_graph(), _make_graph(),
+            _make_graph(),
+            _make_graph(),
             old_report={"health": {"score": 70, "grade": "B"}},
             new_report={"health": {"score": 80, "grade": "A"}},
         )
@@ -266,12 +302,14 @@ class TestFormat:
 
     def test_text_format(self):
         from graphify_plus.review.graph_diff import diff_graphs, format_text_diff
+
         d = diff_graphs(_make_graph(), _make_graph())
         text = format_text_diff(d)
         assert "Graph diff" in text
 
     def test_json_serialisable(self):
         from graphify_plus.review.graph_diff import diff_graphs
+
         d = diff_graphs(_make_graph(), _make_graph())
         # Must serialise without errors
         encoded = json.dumps(d)
@@ -281,25 +319,31 @@ class TestFormat:
 
 # ─── Threshold ─────────────────────────────────────────────────────────────
 
+
 class TestThreshold:
     def test_meets_threshold_pass(self):
         from graphify_plus.review.graph_diff import diff_meets_threshold
+
         assert diff_meets_threshold({"overall_severity": "LOW"}, "HIGH") is True
 
     def test_meets_threshold_fail(self):
         from graphify_plus.review.graph_diff import diff_meets_threshold
+
         assert diff_meets_threshold({"overall_severity": "CRITICAL"}, "HIGH") is False
 
     def test_threshold_at_boundary(self):
         from graphify_plus.review.graph_diff import diff_meets_threshold
+
         assert diff_meets_threshold({"overall_severity": "HIGH"}, "HIGH") is True
 
 
 # ─── Edge cases ─────────────────────────────────────────────────────────────
 
+
 class TestEdgeCases:
     def test_identical_graphs(self):
         from graphify_plus.review.graph_diff import diff_graphs
+
         G = _make_graph()
         d = diff_graphs(G, G)
         assert len(d["nodes_added"]) == 0
@@ -307,30 +351,34 @@ class TestEdgeCases:
 
     def test_empty_to_full(self):
         from graphify_plus.review.graph_diff import diff_graphs
+
         empty = nx.Graph()
         d = diff_graphs(empty, _make_graph())
         assert len(d["nodes_added"]) == 4
 
     def test_full_to_empty(self):
         from graphify_plus.review.graph_diff import diff_graphs
+
         d = diff_graphs(_make_graph(), nx.Graph())
         assert len(d["nodes_removed"]) == 4
 
     def test_directed_to_undirected_handled(self):
         from graphify_plus.review.graph_diff import diff_graphs
+
         old = nx.DiGraph()
-        old.add_edge("a","b", relation="calls")
+        old.add_edge("a", "b", relation="calls")
         new = nx.Graph()
-        new.add_edge("a","b", relation="calls")
+        new.add_edge("a", "b", relation="calls")
         # Both should diff cleanly
         d = diff_graphs(old, new)
         assert "summary" in d
 
     def test_multigraph_handled(self):
         from graphify_plus.review.graph_diff import diff_graphs
+
         G = nx.MultiGraph()
-        G.add_edge("a","b", relation="calls")
-        G.add_edge("a","b", relation="wraps")  # multi-edge
+        G.add_edge("a", "b", relation="calls")
+        G.add_edge("a", "b", relation="wraps")  # multi-edge
         d = diff_graphs(G, G)
         # Identical multigraph diff: 0 changes
         assert d["summary"]["node_delta"] == 0
@@ -338,9 +386,11 @@ class TestEdgeCases:
 
 # ─── CLI ────────────────────────────────────────────────────────────────────
 
+
 class TestDiffCLI:
     def test_basic_run(self, tmp_path, capsys):
         from graphify_plus.review.cli import main
+
         old_path = tmp_path / "old.json"
         new_path = tmp_path / "new.json"
         _save_graph(_make_graph(), old_path)
@@ -352,6 +402,7 @@ class TestDiffCLI:
 
     def test_missing_file(self, tmp_path):
         from graphify_plus.review.cli import main
+
         good = tmp_path / "g.json"
         _save_graph(_make_graph(), good)
         rc = main([str(tmp_path / "nope.json"), str(good), "--quiet"])
@@ -359,23 +410,30 @@ class TestDiffCLI:
 
     def test_json_output(self, tmp_path):
         from graphify_plus.review.cli import main
+
         old_path = tmp_path / "old.json"
         new_path = tmp_path / "new.json"
         out_path = tmp_path / "diff.json"
         _save_graph(_make_graph(), old_path)
         _save_graph(_make_graph(extra_nodes={"x": {"label": "X"}}), new_path)
-        rc = main([
-            str(old_path), str(new_path),
-            "--format", "json",
-            "--output", str(out_path),
-            "--quiet",
-        ])
+        rc = main(
+            [
+                str(old_path),
+                str(new_path),
+                "--format",
+                "json",
+                "--output",
+                str(out_path),
+                "--quiet",
+            ]
+        )
         assert rc == 0
         data = json.loads(out_path.read_text())
         assert "summary" in data
 
     def test_fail_above_threshold(self, tmp_path):
         from graphify_plus.review.cli import main
+
         old_path = tmp_path / "old.json"
         new_path = tmp_path / "new.json"
         old = _make_graph()
@@ -383,15 +441,20 @@ class TestDiffCLI:
         new.remove_node("rationale")  # creates orphan → HIGH severity
         _save_graph(old, old_path)
         _save_graph(new, new_path)
-        rc = main([
-            str(old_path), str(new_path),
-            "--fail-above", "MEDIUM",
-            "--quiet",
-        ])
+        rc = main(
+            [
+                str(old_path),
+                str(new_path),
+                "--fail-above",
+                "MEDIUM",
+                "--quiet",
+            ]
+        )
         assert rc == 1  # exceeds MEDIUM threshold
 
     def test_text_format(self, tmp_path, capsys):
         from graphify_plus.review.cli import main
+
         old_path = tmp_path / "old.json"
         new_path = tmp_path / "new.json"
         _save_graph(_make_graph(), old_path)


### PR DESCRIPTION
Phase 8 of EXECUTION_PLAN.md. Implements Features 12, 13, 17, 27, 28.

## Summary
- **interface/privacy.py** — REQUIRED redaction layer for every external-data ingest path. Idempotent. Patterns: email, JWT, API keys (sk-, xoxb-, ghp_, AKIA, AIza), long hex, IPv4/v6, phones.
- **git_silo** — bulk 'git log --numstat' parsed in-process; volatility / age_score / legacy_flag attached as node attrs.
- **telemetry** — JSONL stdlib-only ingest; every payload goes through redact_dict before aggregation; per-span schema fingerprint attached as data_shape.
- **lockfile** — npm/pypi/poetry parsers; 'dependency' nodes + 'depends_on' edges from synthetic repo root.
- **blast_radius** — reverse-BFS along depends_on/imports/calls; depth-ranked hits + remediation hint.
- New CLIs: gp enrich {git,lockfile,telemetry}, gp blast-radius PACKAGE.

## Tests
181 passed (+21 new). Hypothesis property: redact() is idempotent on random input.

## Out of scope per user direction
- Streaming OTLP support (we accept JSONL via stdlib only — no opentelemetry-proto/ijson dep).
- Hosted-mode telemetry transport (Phase 11).