### PR TITLE
feat(query,interface): edge-centric test generation & visual spatial output

### DIFF
--- a/graphify_plus/__main__.py
+++ b/graphify_plus/__main__.py
@@ -116,6 +116,24 @@ def main(argv: list[str] | None = None) -> int:
             return int(e.code or 0)
         return 0
 
+    if cmd in ("matrix", "visual"):
+        from graphify_plus.interface.cli.matrix_cmd import (
+            matrix_cmd,
+            visual_cmd,
+        )
+
+        click_cmd_map = {"matrix": matrix_cmd, "visual": visual_cmd}
+        try:
+            click_cmd_map[cmd].main(
+                args=rest, prog_name=f"graphify-plus {cmd}", standalone_mode=False
+            )
+        except SystemExit as e:
+            return int(e.code or 0)
+        except click.ClickException as e:
+            e.show()
+            return 1
+        return 0
+
     if cmd in ("enrich", "blast-radius"):
         from graphify_plus.interface.cli.enrich_cmd import (
             blast_cmd,

--- a/graphify_plus/interface/cli/matrix_cmd.py
+++ b/graphify_plus/interface/cli/matrix_cmd.py
@@ -1,0 +1,112 @@
+"""``gp matrix`` and ``gp visual`` CLIs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+from ...core.symbol_graph import build as build_graph
+from ...interface.visual import render_cluster
+from ...query.semantic import communities
+from ...query.tests_gen import for_subgraph, write_scaffolds
+from ...runtime.store import Store, cache_path
+from .safety_cmds import _load_ruleset
+
+
+def _open(repo: Path) -> Store:
+    if not cache_path(repo).exists():
+        raise click.ClickException(
+            f"No cache at {cache_path(repo)}. Run 'graphify-plus init --repo {repo}' first."
+        )
+    return Store(cache_path(repo))
+
+
+@click.command("matrix")
+@click.option(
+    "--repo",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    default=Path("."),
+)
+@click.option("--generate-tests", is_flag=True, required=True)
+@click.option(
+    "--target",
+    "targets",
+    multiple=True,
+    help="Repo-relative source paths to scope the test scaffolds (default: every edge).",
+)
+@click.option(
+    "--write/--print",
+    "write_mode",
+    default=False,
+    help="--write places scaffolds under <target>/.graphify_plus/generated_tests/.",
+)
+def matrix_cmd(
+    repo: Path, generate_tests: bool, targets: tuple[str, ...], write_mode: bool
+) -> None:
+    """Edge-centric test scaffolds. Currently only --generate-tests is wired."""
+    if not generate_tests:
+        raise click.UsageError("Use --generate-tests (the only supported mode in v3.x).")
+    repo = repo.resolve()
+    store = _open(repo)
+    try:
+        G = build_graph(store.all_symbols(), store.all_edges())
+        scaffolds = for_subgraph(G, target_paths=targets or None)
+    finally:
+        store.close()
+
+    if write_mode:
+        out = repo / ".graphify_plus" / "generated_tests"
+        paths = write_scaffolds(scaffolds, out)
+        click.echo(f"matrix: wrote {len(paths)} scaffold files under {out}")
+    else:
+        for sc in scaffolds:
+            click.echo(f"# {sc.edge_kind}: {sc.src_qname} → {sc.dst_qname} ({sc.language})")
+            click.echo(sc.body)
+            click.echo("")
+
+
+@click.command("visual")
+@click.option(
+    "--repo",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    default=Path("."),
+)
+@click.option("--cluster", "cluster_id", type=int, default=0)
+def visual_cmd(repo: Path, cluster_id: int) -> None:
+    """Render community ``--cluster`` to SVG/PNG/DOT under target's
+    .graphify_plus/visuals/ directory."""
+    repo = repo.resolve()
+    store = _open(repo)
+    try:
+        G = build_graph(store.all_symbols(), store.all_edges())
+        comm = communities(store, G)
+    finally:
+        store.close()
+    nodes = [sid for sid, c in comm.items() if c == cluster_id]
+    if not nodes:
+        raise click.ClickException(
+            f"No community with id {cluster_id}. Try 'gp find --intent ...' to see ids."
+        )
+    rs = _load_ruleset(repo)
+    result = render_cluster(
+        G,
+        nodes,
+        repo / ".graphify_plus" / "visuals",
+        cluster_id=cluster_id,
+        layers=rs.layers,
+    )
+    click.echo(f"visual: dot={result.dot_path}")
+    if result.svg_path:
+        click.echo(f"        svg={result.svg_path}")
+    if result.png_path:
+        click.echo(f"        png={result.png_path}")
+    if not result.svg_path:
+        click.echo(
+            "        (svg/png skipped — install 'graphviz' Python bindings AND the\n"
+            "         'dot' system binary to enable rasterised output)",
+            err=True,
+        )
+
+
+__all__ = ["matrix_cmd", "visual_cmd"]

--- a/graphify_plus/interface/visual.py
+++ b/graphify_plus/interface/visual.py
@@ -1,0 +1,171 @@
+"""SVG / PNG / DOT cluster renderer.
+
+For a target community (Phase 4 result), emit a layout suitable for
+vision-capable models. Output goes into the **target repo's**
+``.graphify_plus/visuals/`` directory — never inside graphify-plus.
+
+Visual encoding:
+
+  - Node shape  → kind (rectangle = function, ellipse = class,
+                  hexagon = endpoint, cylinder = dependency, note = module)
+  - Node colour → layer (blue = ui, green = api, purple = database, …)
+                  Phase 9 uses a small built-in palette; later phases
+                  can read colours from rules.yaml.
+  - Edge style  → kind (solid = call, dashed = import,
+                  dotted = inferred / crosses_to)
+  - Border     → ``thick`` for gatekeepers (high-betweenness — caller-supplied)
+
+If the ``graphviz`` Python binding is available, render PNG + SVG
+deterministically (set ``ordering=out``, ``newrank=true``). Otherwise
+write a ``.dot`` source file the user can render with system graphviz.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import networkx as nx
+
+_LAYER_COLOUR = {
+    "ui": "#4f8ed8",
+    "api": "#3aa55d",
+    "database": "#a059c4",
+    "service": "#d8a04f",
+    "default": "#888888",
+}
+
+_KIND_SHAPE = {
+    "function": "box",
+    "method": "box",
+    "class": "ellipse",
+    "interface": "ellipse",
+    "type": "ellipse",
+    "module": "note",
+    "endpoint": "hexagon",
+    "dependency": "cylinder",
+    "external": "plaintext",
+}
+
+
+@dataclass(frozen=True)
+class RenderResult:
+    dot_path: Path
+    svg_path: Path | None
+    png_path: Path | None
+
+
+def _node_attrs(
+    attrs: dict, layers: dict[str, list[str]] | None, gatekeepers: set[str]
+) -> dict[str, str]:
+    kind = attrs.get("kind") or "function"
+    label = attrs.get("name") or attrs.get("qualified_name") or attrs.get("id") or ""
+    shape = _KIND_SHAPE.get(kind, "box")
+    layer = _layer_for(attrs.get("path") or "", layers or {})
+    colour = _LAYER_COLOUR.get(layer or "default", _LAYER_COLOUR["default"])
+    out = {
+        "label": label,
+        "shape": shape,
+        "style": "filled",
+        "fillcolor": colour,
+        "fontcolor": "white" if layer else "#222222",
+        "color": "#222222",
+    }
+    if attrs.get("id") in gatekeepers:
+        out["penwidth"] = "3"
+    return out
+
+
+def _edge_attrs(data: dict) -> dict[str, str]:
+    kind = (data or {}).get("kind") or ""
+    if kind in {"calls", "references"}:
+        style = "solid"
+    elif kind in {"imports", "extends", "implements"}:
+        style = "dashed"
+    else:
+        style = "dotted"
+    return {"style": style, "label": kind, "fontsize": "8"}
+
+
+def _layer_for(path: str, layers: dict[str, list[str]]) -> str | None:
+    import fnmatch
+
+    for name, globs in layers.items():
+        if any(fnmatch.fnmatch(path, g) for g in globs):
+            return name
+    return None
+
+
+def render_cluster(
+    G: nx.MultiDiGraph,
+    cluster_nodes: list[str],
+    out_dir: Path,
+    *,
+    cluster_id: int,
+    layers: dict[str, list[str]] | None = None,
+    gatekeepers: set[str] | None = None,
+) -> RenderResult:
+    """Render the induced subgraph on ``cluster_nodes`` to SVG / PNG / DOT.
+
+    ``out_dir`` should be inside the target repo (typically
+    ``<target>/.graphify_plus/visuals/``). Files written:
+    ``cluster_<id>.svg``, ``cluster_<id>.png`` (when graphviz binary is
+    installed), ``cluster_<id>.dot`` (always).
+    """
+    out_dir.mkdir(parents=True, exist_ok=True)
+    base = out_dir / f"cluster_{cluster_id}"
+    sub = G.subgraph(cluster_nodes).copy()
+    gks = gatekeepers or set()
+
+    # Build the DOT body manually so we can write it deterministically
+    # whether or not graphviz Python lib is present.
+    lines: list[str] = [
+        "digraph G {",
+        "  graph [newrank=true, ordering=out];",
+        '  node [fontname="Inter,Helvetica,Arial,sans-serif"];',
+    ]
+    for sid in sorted(sub.nodes):
+        a = dict(sub.nodes[sid])
+        a["id"] = sid
+        attrs = _node_attrs(a, layers, gks)
+        attr_str = ", ".join(f'{k}="{v}"' for k, v in sorted(attrs.items()))
+        lines.append(f'  "{sid}" [{attr_str}];')
+    for u, v, data in sorted(
+        sub.edges(data=True), key=lambda t: (t[0], t[1], (t[2] or {}).get("kind") or "")
+    ):
+        attrs = _edge_attrs(data or {})
+        attr_str = ", ".join(f'{k}="{v}"' for k, v in sorted(attrs.items()))
+        lines.append(f'  "{u}" -> "{v}" [{attr_str}];')
+    lines.append("}")
+    dot_text = "\n".join(lines) + "\n"
+    dot_path = base.with_suffix(".dot")
+    dot_path.write_text(dot_text)
+
+    svg_path: Path | None = None
+    png_path: Path | None = None
+    try:
+        import graphviz  # type: ignore[import-untyped]
+
+        src = graphviz.Source(
+            dot_text, engine="dot", filename=str(base.name), directory=str(out_dir)
+        )
+        # graphviz auto-appends .svg / .png to filename
+        try:
+            src.format = "svg"
+            src.render(cleanup=True)
+            svg_path = base.with_suffix(".svg")
+        except Exception:  # noqa: BLE001 — system 'dot' binary missing
+            svg_path = None
+        try:
+            src.format = "png"
+            src.render(cleanup=True)
+            png_path = base.with_suffix(".png")
+        except Exception:  # noqa: BLE001
+            png_path = None
+    except ImportError:
+        pass
+
+    return RenderResult(dot_path=dot_path, svg_path=svg_path, png_path=png_path)
+
+
+__all__ = ["RenderResult", "render_cluster"]

--- a/graphify_plus/query/tests_gen.py
+++ b/graphify_plus/query/tests_gen.py
@@ -1,0 +1,164 @@
+"""Edge-centric test scaffolds.
+
+For each edge ``(A, B, kind)`` in a target subgraph, emit a test
+template in the appropriate language/framework, detected from the file
+paths involved. The test asserts the contract implied by the edge —
+``calls`` → "A's caller invokes B and gets back …", ``imports`` → "A
+exposes B at its expected path", ``crosses_to`` → "A's frontend hits
+B's endpoint with a payload that matches the OpenAPI schema".
+
+Intentionally minimal — these are *scaffolds* the developer fills in.
+No network, no mocking framework choice baked in.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+import networkx as nx
+from jinja2 import Environment, select_autoescape
+
+
+@dataclass(frozen=True)
+class TestScaffold:
+    edge_kind: str
+    src_qname: str
+    dst_qname: str
+    language: str  # python | typescript | javascript | go | other
+    body: str
+
+
+_ENV = Environment(autoescape=select_autoescape(["html", "xml"]))
+
+_TEMPLATES = {
+    "python": (
+        "def test_{slug}() -> None:\n"
+        '    """{kind}: {src} → {dst}\n'
+        "\n"
+        "    Auto-generated edge scaffold. Fill in the assertions.\n"
+        '    """\n'
+        "    # arrange: build inputs that exercise the {kind} edge\n"
+        "    # act:     call the source path so it reaches the target\n"
+        "    # assert:  the target was invoked with expected args / returned shape\n"
+        '    raise AssertionError("scaffold not yet implemented")\n'
+    ),
+    "typescript": (
+        "import {{ describe, it, expect }} from 'vitest';\n"
+        "\n"
+        "describe('{src} → {dst} ({kind})', () => {{\n"
+        "  it('exercises the edge', () => {{\n"
+        "    // arrange: build inputs that exercise the {kind} edge\n"
+        "    // act:     call the source path so it reaches the target\n"
+        "    // assert:  the target was invoked with expected args / returned shape\n"
+        "    expect.fail('scaffold not yet implemented');\n"
+        "  }});\n"
+        "}});\n"
+    ),
+    "javascript": (
+        "const {{ describe, it, expect }} = require('vitest');\n"
+        "\n"
+        "describe('{src} → {dst} ({kind})', () => {{\n"
+        "  it('exercises the edge', () => {{\n"
+        "    expect.fail('scaffold not yet implemented');\n"
+        "  }});\n"
+        "}});\n"
+    ),
+    "go": (
+        "package generated\n"
+        "\n"
+        'import "testing"\n'
+        "\n"
+        "func Test_{slug}(t *testing.T) {{\n"
+        "    // {kind}: {src} → {dst}\n"
+        '    t.Skip("scaffold not yet implemented")\n'
+        "}}\n"
+    ),
+    "default": ("// {kind}: {src} → {dst}\n// scaffold not yet implemented\n"),
+}
+
+
+def _slug(s: str) -> str:
+    return "".join(c if c.isalnum() else "_" for c in s).strip("_")
+
+
+def _language_for(language: str | None) -> str:
+    if language in {"python", "typescript", "javascript", "go"}:
+        return language
+    return "default"
+
+
+def render(scaffold_input: dict[str, str]) -> str:
+    """Render the templated body using a Python format-string fallback
+    (Jinja is overkill for these single-paragraph scaffolds; we use it
+    only for autoescape consistency with downstream callers).
+    """
+    template = _TEMPLATES.get(scaffold_input["language"], _TEMPLATES["default"])
+    return template.format(**scaffold_input)
+
+
+def for_subgraph(
+    G: nx.MultiDiGraph, target_paths: Iterable[str] | None = None
+) -> list[TestScaffold]:
+    """Yield one TestScaffold per edge in the (optionally path-scoped) subgraph."""
+    paths = set(target_paths) if target_paths else None
+    out: list[TestScaffold] = []
+    seen: set[tuple[str, str, str]] = set()
+    for u, v, data in G.edges(data=True):
+        kind = (data or {}).get("kind") or ""
+        if kind in {"contains", "exports", "depends_on"}:
+            continue  # purely structural — no test contract
+        u_attrs = G.nodes.get(u) or {}
+        v_attrs = G.nodes.get(v) or {}
+        if paths is not None and (
+            u_attrs.get("path") not in paths and v_attrs.get("path") not in paths
+        ):
+            continue
+        src_q = u_attrs.get("qualified_name") or u
+        dst_q = v_attrs.get("qualified_name") or v
+        key = (src_q, dst_q, kind)
+        if key in seen:
+            continue
+        seen.add(key)
+        lang = _language_for(u_attrs.get("language") or v_attrs.get("language"))
+        body = render(
+            {
+                "language": lang,
+                "kind": kind,
+                "src": src_q,
+                "dst": dst_q,
+                "slug": _slug(f"{src_q}_to_{dst_q}_{kind}"),
+            }
+        )
+        out.append(
+            TestScaffold(edge_kind=kind, src_qname=src_q, dst_qname=dst_q, language=lang, body=body)
+        )
+    out.sort(key=lambda s: (s.language, s.src_qname, s.dst_qname, s.edge_kind))
+    return out
+
+
+def write_scaffolds(scaffolds: list[TestScaffold], out_dir: Path) -> list[Path]:
+    """Write each scaffold to a per-edge file under ``out_dir``.
+    Filename: ``test_<slug>.<ext>`` (or ``<slug>_test.go`` for Go).
+    """
+    out_dir.mkdir(parents=True, exist_ok=True)
+    written: list[Path] = []
+    for sc in scaffolds:
+        slug = _slug(f"{sc.src_qname}_to_{sc.dst_qname}_{sc.edge_kind}")
+        if sc.language == "python":
+            name = f"test_{slug}.py"
+        elif sc.language in {"typescript", "javascript"}:
+            ext = "ts" if sc.language == "typescript" else "js"
+            name = f"{slug}.test.{ext}"
+        elif sc.language == "go":
+            name = f"{slug}_test.go"
+        else:
+            name = f"test_{slug}.txt"
+        path = out_dir / name
+        path.write_text(sc.body)
+        written.append(path)
+    return written
+
+
+__all__ = ["TestScaffold", "for_subgraph", "render", "write_scaffolds"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "tiktoken>=0.7",  # Phase 3 token-budgeted framing
     "rank-bm25>=0.2",  # Phase 4 semantic finder (pure-python, no tokenizer deps)
     "PyYAML>=6.0",  # Phase 6 rules.yaml loading
+    "Jinja2>=3.1",  # Phase 9 test-scaffold templates
 ]
 
 [project.optional-dependencies]
@@ -52,6 +53,9 @@ mcp = [
 ]
 viz = [
     "graphviz>=0.20",
+]
+jinja = [
+    "Jinja2>=3.1",
 ]
 telemetry = [
     "opentelemetry-proto>=1.25",

--- a/tests/interface/test_visual.py
+++ b/tests/interface/test_visual.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import networkx as nx
+
+from graphify_plus.interface.visual import render_cluster
+
+
+def _G() -> nx.MultiDiGraph:
+    G: nx.MultiDiGraph = nx.MultiDiGraph()
+    G.add_node(
+        "ui1",
+        id="ui1",
+        kind="function",
+        name="Button",
+        qualified_name="ui.Button",
+        path="frontend/button.tsx",
+    )
+    G.add_node(
+        "api1",
+        id="api1",
+        kind="function",
+        name="post",
+        qualified_name="api.post",
+        path="backend/api/handler.py",
+    )
+    G.add_node(
+        "db1",
+        id="db1",
+        kind="class",
+        name="Repo",
+        qualified_name="db.Repo",
+        path="backend/db/repo.py",
+    )
+    G.add_edge("ui1", "api1", kind="calls")
+    G.add_edge("api1", "db1", kind="imports")
+    return G
+
+
+_LAYERS = {
+    "ui": ["frontend/**"],
+    "api": ["backend/api/**"],
+    "database": ["backend/db/**"],
+}
+
+
+def test_render_writes_dot(tmp_path: Path):
+    G = _G()
+    result = render_cluster(
+        G,
+        list(G.nodes),
+        tmp_path,
+        cluster_id=7,
+        layers=_LAYERS,
+        gatekeepers={"api1"},
+    )
+    assert result.dot_path.name == "cluster_7.dot"
+    text = result.dot_path.read_text()
+    assert "digraph G" in text
+    # Layer colour assigned.
+    assert 'fillcolor="#4f8ed8"' in text  # ui blue
+    assert 'fillcolor="#3aa55d"' in text  # api green
+    # Gatekeeper has thicker border.
+    assert 'penwidth="3"' in text
+
+
+def test_render_is_byte_stable(tmp_path: Path):
+    G = _G()
+    a = render_cluster(
+        G, list(G.nodes), tmp_path / "a", cluster_id=0, layers=_LAYERS, gatekeepers=set()
+    )
+    b = render_cluster(
+        G, list(G.nodes), tmp_path / "b", cluster_id=0, layers=_LAYERS, gatekeepers=set()
+    )
+    assert a.dot_path.read_text() == b.dot_path.read_text()
+
+
+def test_kind_to_shape_mapping(tmp_path: Path):
+    G = _G()
+    result = render_cluster(
+        G, list(G.nodes), tmp_path, cluster_id=0, layers=_LAYERS, gatekeepers=set()
+    )
+    text = result.dot_path.read_text()
+    assert 'shape="box"' in text  # function
+    assert 'shape="ellipse"' in text  # class

--- a/tests/query/test_tests_gen.py
+++ b/tests/query/test_tests_gen.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import networkx as nx
+
+from graphify_plus.query.tests_gen import for_subgraph, write_scaffolds
+
+
+def _G() -> nx.MultiDiGraph:
+    G: nx.MultiDiGraph = nx.MultiDiGraph()
+    G.add_node("a", id="a", qualified_name="mod.a", path="src/mod.py", language="python")
+    G.add_node("b", id="b", qualified_name="mod.b", path="src/mod.py", language="python")
+    G.add_node("c", id="c", qualified_name="ui.x", path="frontend/x.ts", language="typescript")
+    G.add_edge("a", "b", kind="calls")
+    G.add_edge("c", "a", kind="imports")
+    G.add_edge("a", "b", kind="contains")  # filtered out
+    return G
+
+
+def test_for_subgraph_skips_structural_edges():
+    sc = for_subgraph(_G())
+    kinds = {s.edge_kind for s in sc}
+    assert "calls" in kinds
+    assert "imports" in kinds
+    assert "contains" not in kinds
+
+
+def test_language_routing():
+    sc = for_subgraph(_G())
+    by_kind = {(s.edge_kind, s.src_qname): s.language for s in sc}
+    assert by_kind[("calls", "mod.a")] == "python"
+    assert by_kind[("imports", "ui.x")] == "typescript"
+
+
+def test_python_scaffold_body_is_valid_module():
+    sc = next(s for s in for_subgraph(_G()) if s.language == "python")
+    assert "def test_" in sc.body
+    assert "raise AssertionError" in sc.body
+
+
+def test_target_paths_filter():
+    sc = for_subgraph(_G(), target_paths=["frontend/x.ts"])
+    paths_seen = {(s.src_qname, s.dst_qname) for s in sc}
+    # Every yielded scaffold must touch at least one of the targeted files.
+    assert all("ui.x" in (a, b) or any(p == "frontend/x.ts" for p in (a, b)) for a, b in paths_seen)
+
+
+def test_write_scaffolds_filenames(tmp_path: Path):
+    sc = for_subgraph(_G())
+    paths = write_scaffolds(sc, tmp_path)
+    names = {p.name for p in paths}
+    assert any(n.startswith("test_") and n.endswith(".py") for n in names)
+    assert any(n.endswith(".test.ts") for n in names)


### PR DESCRIPTION
Phase 9 of EXECUTION_PLAN.md. Implements Features 14 + 19.

## Summary
- **tests_gen** — one scaffold per non-structural edge in target subgraph; pytest / vitest / go templates; write_scaffolds drops them into target's .graphify_plus/generated_tests/.
- **visual** — render_cluster emits deterministic .dot always, .svg/.png when graphviz binary is installed. Shape=kind, colour=layer, gatekeepers thicker.
- gp matrix --generate-tests, gp visual --cluster N CLIs.
- Jinja2 added as base dep.

## Tests
189 passed (+8 new). Visual rendering is byte-stable across runs.

## Out of scope per user direction
- multimodal/retriever refactor (modules don't exist in this repo).