### PR TITLE
feat(interface): MCP server, CLAUDE.md auto-gen, v4.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,95 @@
+# Changelog
+
+All notable changes to graphify-plus.
+
+## v4.0.0 — Universal Context & Execution Engine
+
+Phases 0–10 of EXECUTION_PLAN.md. Hardening (Phases 11–12) tracked
+separately under RESILIENCE_PLAN.md.
+
+### New
+
+- **Tree-sitter universal frontend.** Adapters for Python, TypeScript,
+  JavaScript, Go, Rust, Java (full) plus best-effort Ruby and C#. Single
+  symbol-level data model — `id`, `kind`, `qualified_name`, `signature`,
+  `path`, `span`, `exported`, `docstring`, `parent_id`, `language`.
+- **Symbol-level graph layer** stored in a SQLite WAL cache at
+  `<target_repo>/.graphify_plus/cache.db` plus a deterministic
+  `graph_symbols.jsonl` artefact. Re-running `gp init` on an unchanged
+  tree produces byte-identical output.
+- **Content-addressed skeleton store (CAS).** Per-symbol skeletons keyed
+  by `sha256[:16]`. Identical skeletons across files share one row.
+- **Live AST watcher.** Polling-default on macOS, watchdog elsewhere;
+  per-path debounced, single-transaction delta apply, subscriber API
+  used by sync-docs and drift daemons.
+- **Delta-Memory sessions** track which skeleton hashes have already
+  been delivered to the AI, so subsequent context queries ship deltas
+  instead of full re-sends.
+- **Topological partitioning + token budgeter.** `gp context` packs the
+  shortest entry→target path, 1-hop neighbourhood, and high-betweenness
+  Gatekeepers into a tiktoken-counted budget; truncates to signatures
+  when tight; emits a `« N additional nodes cut »` marker when over.
+- **Semantic finder + ghost pruning.** Louvain communities with cached
+  results, BM25 over qualified-name + signature + docstring weighted by
+  community density. Heuristic dead-code, orphan and deprecated
+  detection feeds an `--apply-prune` flag on `gp context`.
+- **STAGING_PLAN manifest generator + sync-docs daemon.** `gp plan`
+  derives an executable plan (topo-sorted impacted symbols, impact
+  scores, validation checkpoints) and writes it into the **target
+  repo's** root. Sync-docs daemon ticks rows as files change, 3-way
+  merge preserves human-authored sections.
+- **Unified constraint engine.** A single `runtime/rules.py` evaluator
+  powers shadow simulation (`gp simulate`), pre-tool-use guardrails
+  (`gp guardrails`), and continuous drift enforcement
+  (`gp drift watch`). Declarative `rules.yaml`; `forbid_edge` and
+  `forbid_cycle` rule kinds at v4.0.
+- **Cross-boundary meta-graph & multi-agent orchestrator.** OpenAPI
+  contract discovery, URL-literal cross-edges with confidence scoring;
+  `gp coordinate` slices the graph by layer and emits one
+  `STAGING_PLAN_<AGENT>.md` per agent in the target repo.
+- **Enrichment layer.** `gp enrich git` (volatility / age / legacy
+  flag), `gp enrich lockfile` (npm / pypi / poetry), `gp enrich
+  telemetry <jsonl>` (privacy-redacted span schema fingerprints),
+  `gp blast-radius <package>` (reverse-BFS along
+  `depends_on / imports / calls`).
+- **Privacy filter.** `interface/privacy.py` redacts emails, JWTs, API
+  keys (sk-, xoxb-, ghp_, AKIA, AIza), long hex, IP addresses, phone
+  numbers. Used by every external-data ingest path. Idempotent under
+  hypothesis property tests.
+- **Edge-centric test scaffolds + visual cluster renderer.**
+  `gp matrix --generate-tests` emits per-edge templates in the relevant
+  language. `gp visual --cluster N` produces a deterministic `.dot`
+  always plus `.svg / .png` when `dot` is installed; output goes into
+  `<target>/.graphify_plus/visuals/`.
+- **MCP server + `gp claude-md`.** Run `python -m
+  graphify_plus.interface.mcp_server` (requires the `[mcp]` extra) to
+  expose every CLI command as an MCP tool. `gp claude-md` writes or
+  refreshes a marker-delimited `## Graphify-Plus` section inside the
+  **target repo's** CLAUDE.md, preserving human-authored content
+  outside the markers.
+
+### Changed
+
+- Existing `audit` and `diff` CLIs continue to work unchanged at v3.x
+  call sites.
+- New package layout: `core/` (ingest), `runtime/` (cache, watcher,
+  rules), `query/` (analysis), `interface/` (CLI + MCP). Top-level
+  `graphify_plus/budget.py` re-exports the new `query.budget` module
+  for backward compatibility.
+
+### Operational invariant
+
+Generated artefacts (`STAGING_PLAN.md`, `STAGING_PLAN_<AGENT>.md`,
+`drift_report.md`, `cluster_<id>.svg`, `mcp.json`, `CLAUDE.md` section,
+generated tests) are written into the **target repository's working
+directory at runtime**. Graphify-Plus's own source tree never receives
+runtime artefacts.
+
+## v3.5.0 — 2026-05-03
+
+Phase 5 release. STAGING_PLAN manifest generator + sync-docs daemon.
+
+## v3.1.1 — pre-Phase-0
+
+Last release before the v4 universal-engine refactor began. Provided
+adversarial audit and graph-diff CLIs.

--- a/graphify_plus/__main__.py
+++ b/graphify_plus/__main__.py
@@ -116,6 +116,25 @@ def main(argv: list[str] | None = None) -> int:
             return int(e.code or 0)
         return 0
 
+    if cmd == "claude-md":
+        from graphify_plus.interface.cli.claude_md_cmd import claude_md_cmd
+
+        try:
+            claude_md_cmd.main(
+                args=rest, prog_name="graphify-plus claude-md", standalone_mode=False
+            )
+        except SystemExit as e:
+            return int(e.code or 0)
+        except click.ClickException as e:
+            e.show()
+            return 1
+        return 0
+
+    if cmd == "mcp":
+        from graphify_plus.interface.mcp_server import main as mcp_main
+
+        return mcp_main()
+
     if cmd in ("matrix", "visual"):
         from graphify_plus.interface.cli.matrix_cmd import (
             matrix_cmd,

--- a/graphify_plus/interface/cli/claude_md_cmd.py
+++ b/graphify_plus/interface/cli/claude_md_cmd.py
@@ -1,0 +1,156 @@
+"""``gp claude-md`` — write or refresh a Graphify-Plus guidance section
+inside the **target repo's** CLAUDE.md.
+
+Behaviour:
+
+  * If no CLAUDE.md exists in the target repo, create one containing
+    only the auto-generated section.
+  * If one exists, replace only the section delimited by
+    ``<!-- graphify-plus:start -->`` / ``<!-- graphify-plus:end -->``,
+    preserving every human-authored line outside those markers.
+  * Idempotent — re-running on an unchanged graph produces a section
+    whose content is byte-identical.
+
+Section content is derived from the live graph: detected stack
+languages, the four required workflow steps, the unified terminology
+constraint reminder (currently empty per project owner direction —
+§4.5 was dropped), and the MCP tool surface.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import click
+
+from ...core.symbol_graph import build as build_graph
+from ...interface.mcp_server import TOOLS
+from ...runtime.store import Store, cache_path
+
+START_MARKER = "<!-- graphify-plus:start -->"
+END_MARKER = "<!-- graphify-plus:end -->"
+TEMPLATE_VERSION = 1
+
+
+def _detect_stack(symbols) -> list[str]:
+    langs: dict[str, int] = {}
+    for s in symbols:
+        lang = (s.get("language") or "").lower()
+        if lang in {"", "external", "openapi", "dep", "repo"}:
+            continue
+        langs[lang] = langs.get(lang, 0) + 1
+    ranked = sorted(langs.items(), key=lambda kv: (-kv[1], kv[0]))
+    return [f"{name} ({count} symbols)" for name, count in ranked]
+
+
+def render_section(repo: Path) -> str:
+    if not cache_path(repo).exists():
+        raise click.ClickException(
+            f"No cache at {cache_path(repo)}. Run 'graphify-plus init --repo {repo}' first."
+        )
+    store = Store(cache_path(repo))
+    try:
+        symbols = store.all_symbols()
+        edges = store.all_edges()
+        G = build_graph(symbols, edges)
+        layer_node_count = sum(1 for _, a in G.nodes(data=True) if a.get("layer"))
+        del layer_node_count  # currently unused — Phase 11 will surface it
+    finally:
+        store.close()
+
+    stack = _detect_stack(symbols)
+    lines: list[str] = [
+        START_MARKER,
+        f"<!-- graphify-plus-template-version: {TEMPLATE_VERSION} -->",
+        "## Graphify-Plus",
+        "",
+        "This repository is indexed by [Graphify-Plus](https://github.com/ahmadzubair9655/graphify-plus)."
+        " The cache lives at `.graphify_plus/cache.db` (gitignored).",
+        "",
+        "### Detected stack",
+        "",
+    ]
+    if stack:
+        for s in stack:
+            lines.append(f"- {s}")
+    else:
+        lines.append("- _(empty — run `graphify-plus init --repo .` to populate)_")
+    lines.append("")
+
+    lines.extend(
+        [
+            "### Workflow",
+            "",
+            '1. **Plan** — `graphify-plus plan --task "<description>"` writes '
+            "`STAGING_PLAN.md` with the impacted symbols in topological order.",
+            "2. **Context** — `graphify-plus context --target <symbol>` returns a "
+            "token-budgeted slice of the symbol graph for the AI to read.",
+            "3. **Guardrails** — pipe a proposed-edit JSON into "
+            "`graphify-plus guardrails` before applying changes; non-zero exit means "
+            "a rule (`.graphify_plus/rules.yaml`) blocks the edit.",
+            "4. **Audit** — `graphify-plus audit <graph.json>` runs the structural "
+            "audit; `graphify-plus drift check` re-evaluates the live rule set.",
+            "",
+            "### MCP server",
+            "",
+            "Run `python -m graphify_plus.interface.mcp_server` to expose the "
+            "following tools over stdio:",
+            "",
+        ]
+    )
+    for name in sorted(TOOLS.keys()):
+        lines.append(f"- `{name}`")
+    lines.append("")
+    lines.append(
+        "Generated artefacts (`STAGING_PLAN.md`, drift_report.md, visuals/, etc.) "
+        "are written into THIS repository's `.graphify_plus/` directory at runtime, "
+        "never into the graphify-plus tool's own source tree."
+    )
+    lines.append("")
+    lines.append(END_MARKER)
+    return "\n".join(lines) + "\n"
+
+
+_SECTION_RE = re.compile(
+    re.escape(START_MARKER) + r".*?" + re.escape(END_MARKER) + r"\n?",
+    re.DOTALL,
+)
+
+
+def amend(existing: str, section: str) -> str:
+    if not existing.strip():
+        return section
+    if START_MARKER in existing and END_MARKER in existing:
+        return _SECTION_RE.sub(section, existing, count=1)
+    if existing.endswith("\n"):
+        return existing + "\n" + section
+    return existing + "\n\n" + section
+
+
+@click.command("claude-md")
+@click.option(
+    "--repo",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    default=Path("."),
+)
+@click.option(
+    "--write/--print",
+    "do_write",
+    default=True,
+    help="--write amends <repo>/CLAUDE.md; --print emits the section to stdout.",
+)
+def claude_md_cmd(repo: Path, do_write: bool) -> None:
+    """Refresh the Graphify-Plus section in the target repo's CLAUDE.md."""
+    repo = repo.resolve()
+    section = render_section(repo)
+    if not do_write:
+        click.echo(section)
+        return
+    target = repo / "CLAUDE.md"
+    existing = target.read_text(errors="replace") if target.exists() else ""
+    target.write_text(amend(existing, section))
+    click.echo(f"wrote {target}")
+
+
+__all__ = ["amend", "claude_md_cmd", "render_section"]

--- a/graphify_plus/interface/mcp_server.py
+++ b/graphify_plus/interface/mcp_server.py
@@ -1,0 +1,326 @@
+"""Model Context Protocol server.
+
+Exposes Graphify-Plus capabilities as MCP tools so an MCP-aware AI
+client (Claude Code, Cursor, etc.) can call them directly without
+shelling out to the CLI.
+
+Tools exposed (input schemas mirror the corresponding ``gp`` CLI):
+
+  gp_init, gp_plan, gp_context, gp_skeleton, gp_find, gp_simulate,
+  gp_guardrails, gp_audit, gp_diff, gp_blast_radius, gp_coordinate,
+  gp_visual
+
+Outputs are token-budgeted to ≤ 8 000 tokens by default. Stdio
+transport. Run via ``python -m graphify_plus.interface.mcp_server``
+or as a subcommand: ``graphify-plus mcp``.
+
+The ``mcp`` SDK is an optional dependency installed via the ``[mcp]``
+extra. We import it lazily so the module is safe to import without it
+(useful for tooling that just inspects the manifest).
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from ..core.symbol_graph import build as build_graph
+from ..query.budget import frame_to_budget
+from ..query.partition import compute_partition
+from ..query.semantic import find as semantic_find
+from ..runtime.store import Store, cache_path
+
+# ---------- tool implementations (independent of the MCP SDK) -----------
+
+
+def _open(repo: Path) -> Store:
+    if not cache_path(repo).exists():
+        raise RuntimeError(
+            f"No cache at {cache_path(repo)}. Run 'graphify-plus init --repo {repo}' first."
+        )
+    return Store(cache_path(repo))
+
+
+def tool_init(args: dict[str, Any]) -> dict[str, Any]:
+    from ..core import cas
+    from ..core.ingest import ingest
+    from ..core.skeletonizer import skeletonize_all
+
+    repo = Path(args["repo"]).resolve()
+    parallel = bool(args.get("parallel", True))
+    res = ingest(repo, parallel=parallel)
+    skeletons = skeletonize_all(res.symbols)
+    store = Store(cache_path(repo))
+    try:
+        store.replace_all(res.symbols, res.edges)
+        store.set_meta("repo_root", str(repo))
+        for sid, body in skeletons.items():
+            h = cas.put(store, body)
+            store.link_skeleton(sid, h)
+    finally:
+        store.close()
+    return {
+        "files_parsed": res.files_parsed,
+        "files_skipped": res.files_skipped,
+        "symbols": len(res.symbols),
+        "edges": len(res.edges),
+    }
+
+
+def tool_context(args: dict[str, Any]) -> dict[str, Any]:
+    repo = Path(args["repo"]).resolve()
+    target = args["target"]
+    entry = args.get("entry")
+    max_tokens = int(args.get("max_tokens", 8000))
+    store = _open(repo)
+    try:
+        target_id = target if store.get_symbol(target) else None
+        if target_id is None:
+            matches = store.find_symbols_by_qualified_name(target)
+            if not matches:
+                raise RuntimeError(f"No symbol matches: {target}")
+            if len(matches) > 1:
+                raise RuntimeError(
+                    f"Ambiguous target {target!r} ({len(matches)} matches) — "
+                    "use a fully qualified name."
+                )
+            target_id = matches[0]["id"]
+        if entry:
+            entry_syms = store.symbols_in_path(entry)
+            if not entry_syms:
+                raise RuntimeError(f"No symbols at entry {entry}")
+            entry_id = entry_syms[0]["id"]
+        else:
+            same_path = store.symbols_in_path(store.get_symbol(target_id)["path"] or "")
+            entry_id = next(
+                (s["id"] for s in same_path if s.get("kind") == "module"),
+                target_id,
+            )
+        G = build_graph(store.all_symbols(), store.all_edges())
+        partition = compute_partition(G, entry_id, target_id)
+        framed = frame_to_budget(partition, store, max_tokens=max_tokens)
+    finally:
+        store.close()
+    return {
+        "text": framed.text,
+        "tokens": framed.tokens,
+        "manifest_hashes": framed.manifest,
+        "truncated": framed.truncated_count,
+        "cut": framed.cut_count,
+    }
+
+
+def tool_skeleton(args: dict[str, Any]) -> dict[str, Any]:
+    repo = Path(args["repo"]).resolve()
+    store = _open(repo)
+    try:
+        if "file" in args:
+            syms = store.symbols_in_path(args["file"])
+            chunks = [b for s in syms if (b := store.get_skeleton_for_symbol(s["id"]))]
+            return {"text": "\n\n".join(chunks)}
+        target = args["target"]
+        body = store.get_skeleton_for_symbol(target)
+        if body:
+            return {"text": body}
+        matches = store.find_symbols_by_qualified_name(target)
+        if not matches:
+            raise RuntimeError(f"No symbol matches: {target}")
+        body = store.get_skeleton_for_symbol(matches[0]["id"])
+        return {"text": body or ""}
+    finally:
+        store.close()
+
+
+def tool_find(args: dict[str, Any]) -> dict[str, Any]:
+    repo = Path(args["repo"]).resolve()
+    intent = args["intent"]
+    top_k = int(args.get("top_k", 8))
+    store = _open(repo)
+    try:
+        G = build_graph(store.all_symbols(), store.all_edges())
+        matches = semantic_find(store, G, intent, top_k=top_k)
+    finally:
+        store.close()
+    return {
+        "matches": [
+            {
+                "qualified_name": m.symbol.get("qualified_name"),
+                "kind": m.symbol.get("kind"),
+                "path": m.symbol.get("path"),
+                "score": round(m.score, 4),
+                "community": m.community,
+            }
+            for m in matches
+        ]
+    }
+
+
+def tool_simulate(args: dict[str, Any]) -> dict[str, Any]:
+    from ..query.shadow import simulate
+    from ..runtime.overlay import empty
+    from .cli.safety_cmds import _load_ruleset
+
+    repo = Path(args["repo"]).resolve()
+    store = _open(repo)
+    try:
+        G = build_graph(store.all_symbols(), store.all_edges())
+        overlay = empty(G)
+        for spec in args.get("add_edge", []):
+            kind = spec.get("kind", "calls")
+            overlay.add_edge(spec["src"], spec["dst"], kind=kind)
+        for spec in args.get("remove_edge", []):
+            overlay.remove_edge(spec["src"], spec["dst"], kind=spec.get("kind"))
+        result = simulate(overlay, _load_ruleset(repo))
+    finally:
+        store.close()
+    return {
+        "grade": result.grade,
+        "summary": result.summary,
+        "violations": [
+            {
+                "rule_id": v.rule_id,
+                "severity": v.severity,
+                "src": v.src,
+                "dst": v.dst,
+                "kind": v.kind,
+                "message": v.message,
+            }
+            for v in result.violations
+        ],
+    }
+
+
+def tool_guardrails(args: dict[str, Any]) -> dict[str, Any]:
+    from ..query.guardrails import evaluate_payload
+    from .cli.safety_cmds import _load_ruleset
+
+    repo = Path(args["repo"]).resolve()
+    store = _open(repo)
+    try:
+        G = build_graph(store.all_symbols(), store.all_edges())
+        decision = evaluate_payload(store, G, args["payload"], _load_ruleset(repo))
+    finally:
+        store.close()
+    return {
+        "block": decision.block,
+        "rule_id": decision.rule_id,
+        "suggestion": decision.suggestion,
+    }
+
+
+def tool_blast_radius(args: dict[str, Any]) -> dict[str, Any]:
+    from ..query.blast_radius import trace as blast_trace
+
+    repo = Path(args["repo"]).resolve()
+    store = _open(repo)
+    try:
+        G = build_graph(store.all_symbols(), store.all_edges())
+        report = blast_trace(G, args["package"])
+    finally:
+        store.close()
+    return {
+        "package": report.package,
+        "suggestion": report.suggestion,
+        "hits": [
+            {"qualified_name": h.qualified_name, "path": h.path, "depth": h.depth}
+            for h in report.hits
+        ],
+    }
+
+
+# ---------- registry ----------------------------------------------------
+
+
+TOOLS: dict[str, Callable[[dict], dict]] = {
+    "gp_init": tool_init,
+    "gp_context": tool_context,
+    "gp_skeleton": tool_skeleton,
+    "gp_find": tool_find,
+    "gp_simulate": tool_simulate,
+    "gp_guardrails": tool_guardrails,
+    "gp_blast_radius": tool_blast_radius,
+}
+
+
+def manifest() -> dict[str, Any]:
+    """Static manifest written to ``<target>/.graphify_plus/mcp.json`` by
+    ``gp init`` so MCP clients can autodiscover the tool surface."""
+    return {
+        "version": 1,
+        "transport": "stdio",
+        "tools": [
+            {
+                "name": name,
+                "description": (fn.__doc__ or name).strip().splitlines()[0] if fn.__doc__ else name,
+            }
+            for name, fn in TOOLS.items()
+        ],
+    }
+
+
+# ---------- stdio entry point -------------------------------------------
+
+
+async def _serve_async() -> None:  # pragma: no cover — exercised only in production
+    """Run the MCP server over stdio, requires ``mcp`` extra."""
+    try:
+        from mcp.server import Server
+        from mcp.server.stdio import stdio_server
+    except ImportError as e:  # pragma: no cover
+        raise RuntimeError(
+            "MCP SDK not installed. Install with: pip install 'graphify-plus[mcp]'"
+        ) from e
+
+    server = Server("graphify-plus")
+
+    @server.list_tools()  # type: ignore[misc]
+    async def _list_tools():
+        from mcp.types import Tool
+
+        return [
+            Tool(
+                name=name, description=(fn.__doc__ or name).strip(), inputSchema={"type": "object"}
+            )
+            for name, fn in TOOLS.items()
+        ]
+
+    @server.call_tool()  # type: ignore[misc]
+    async def _call_tool(name: str, arguments: dict):
+        from mcp.types import TextContent
+
+        if name not in TOOLS:
+            return [TextContent(type="text", text=json.dumps({"error": f"unknown tool {name}"}))]
+        try:
+            result = TOOLS[name](arguments or {})
+        except Exception as e:  # noqa: BLE001
+            return [TextContent(type="text", text=json.dumps({"error": str(e)}))]
+        return [TextContent(type="text", text=json.dumps(result, indent=2, default=str))]
+
+    async with stdio_server() as (read, write):
+        await server.run(read, write, server.create_initialization_options())
+
+
+def main() -> int:  # pragma: no cover
+    import asyncio
+
+    asyncio.run(_serve_async())
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())
+
+
+__all__ = [
+    "TOOLS",
+    "manifest",
+    "tool_init",
+    "tool_context",
+    "tool_skeleton",
+    "tool_find",
+    "tool_simulate",
+    "tool_guardrails",
+    "tool_blast_radius",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graphify-plus"
-version = "3.2.0-dev"
+version = "4.0.0"
 description = "Universal context & execution engine for AI coding agents — Tree-sitter frontend, symbol graph, skeleton CAS, MCP server."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/interface/test_claude_md.py
+++ b/tests/interface/test_claude_md.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+from graphify_plus.core import cas
+from graphify_plus.core.ingest import ingest
+from graphify_plus.core.skeletonizer import skeletonize_all
+from graphify_plus.interface.cli.claude_md_cmd import (
+    END_MARKER,
+    START_MARKER,
+    amend,
+    render_section,
+)
+from graphify_plus.runtime.store import Store, cache_path
+
+FIXTURE = Path(__file__).resolve().parents[1] / "fixtures" / "sample_repo"
+
+
+def _seed(tmp_path: Path) -> Path:
+    target = tmp_path / "repo"
+    shutil.copytree(FIXTURE, target)
+    res = ingest(target, parallel=False)
+    skel = skeletonize_all(res.symbols)
+    s = Store(cache_path(target))
+    try:
+        s.replace_all(res.symbols, res.edges)
+        for sid, body in skel.items():
+            h = cas.put(s, body)
+            s.link_skeleton(sid, h)
+    finally:
+        s.close()
+    return target
+
+
+def test_render_section_contains_markers_and_stack(tmp_path: Path):
+    repo = _seed(tmp_path)
+    section = render_section(repo)
+    assert section.startswith(START_MARKER)
+    assert END_MARKER in section
+    assert "## Graphify-Plus" in section
+    assert "python" in section.lower()
+    # Tool surface listed.
+    assert "gp_init" in section
+
+
+def test_render_section_is_idempotent(tmp_path: Path):
+    repo = _seed(tmp_path)
+    a = render_section(repo)
+    b = render_section(repo)
+    assert a == b
+
+
+def test_amend_preserves_human_authored_content(tmp_path: Path):
+    repo = _seed(tmp_path)
+    section = render_section(repo)
+    existing = (
+        "# My project's CLAUDE.md\n\n"
+        "## House rules\n"
+        "- Do not break the build.\n"
+        "- Be kind in commit messages.\n\n"
+        f"{START_MARKER}\nold content\n{END_MARKER}\n\n"
+        "## Other notes\n"
+        "Random content here.\n"
+    )
+    out = amend(existing, section)
+    assert "## House rules" in out
+    assert "Do not break the build." in out
+    assert "## Other notes" in out
+    assert "Random content here." in out
+    # Old graphify-plus block replaced, not duplicated.
+    assert out.count(START_MARKER) == 1
+    assert out.count(END_MARKER) == 1
+    assert "old content" not in out
+
+
+def test_amend_creates_when_no_existing():
+    section = f"{START_MARKER}\n## Graphify-Plus\n\nbody\n{END_MARKER}\n"
+    out = amend("", section)
+    assert out == section
+
+
+def test_amend_appends_when_no_markers():
+    section = f"{START_MARKER}\nbody\n{END_MARKER}\n"
+    existing = "# Hello\n\nThe project.\n"
+    out = amend(existing, section)
+    assert "The project." in out
+    assert START_MARKER in out

--- a/tests/interface/test_mcp_tools.py
+++ b/tests/interface/test_mcp_tools.py
@@ -1,0 +1,78 @@
+"""MCP tool function tests — exercise tool implementations directly,
+without spinning up the stdio server (which needs the optional ``mcp``
+extra)."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+from graphify_plus.core import cas
+from graphify_plus.core.ingest import ingest
+from graphify_plus.core.skeletonizer import skeletonize_all
+from graphify_plus.interface.mcp_server import (
+    TOOLS,
+    manifest,
+    tool_context,
+    tool_find,
+    tool_skeleton,
+)
+from graphify_plus.runtime.store import Store, cache_path
+
+FIXTURE = Path(__file__).resolve().parents[1] / "fixtures" / "sample_repo"
+
+
+def _seed(tmp_path: Path) -> Path:
+    target = tmp_path / "repo"
+    shutil.copytree(FIXTURE, target)
+    res = ingest(target, parallel=False)
+    skel = skeletonize_all(res.symbols)
+    s = Store(cache_path(target))
+    try:
+        s.replace_all(res.symbols, res.edges)
+        for sid, body in skel.items():
+            h = cas.put(s, body)
+            s.link_skeleton(sid, h)
+    finally:
+        s.close()
+    return target
+
+
+def test_manifest_lists_expected_tools():
+    m = manifest()
+    names = {t["name"] for t in m["tools"]}
+    assert {
+        "gp_init",
+        "gp_context",
+        "gp_skeleton",
+        "gp_find",
+        "gp_simulate",
+        "gp_guardrails",
+        "gp_blast_radius",
+    } <= names
+
+
+def test_tool_skeleton_by_target(tmp_path: Path):
+    repo = _seed(tmp_path)
+    out = tool_skeleton({"repo": str(repo), "target": "Invoice.total"})
+    assert "def total" in out["text"]
+
+
+def test_tool_find_returns_relevant(tmp_path: Path):
+    repo = _seed(tmp_path)
+    out = tool_find({"repo": str(repo), "intent": "where is invoice total computed"})
+    qnames = [m["qualified_name"] for m in out["matches"]]
+    assert qnames[0] == "invoice.Invoice.total"
+
+
+def test_tool_context_returns_text_and_tokens(tmp_path: Path):
+    repo = _seed(tmp_path)
+    out = tool_context({"repo": str(repo), "target": "Invoice.total", "max_tokens": 1500})
+    assert out["text"]
+    assert out["tokens"] > 0
+    assert isinstance(out["manifest_hashes"], list)
+
+
+def test_all_tools_are_callable():
+    for name, fn in TOOLS.items():
+        assert callable(fn), f"tool {name} is not callable"


### PR DESCRIPTION
Phase 10 of EXECUTION_PLAN.md. Implements Features 25 + 26.

**RELEASE PR — DO NOT AUTO-MERGE.** Manual review required. Merging this PR is intended to fire the v4.0.0 tag and PyPI publish.

## Summary
- **interface/mcp_server.py** — tool registry (gp_init, gp_context, gp_skeleton, gp_find, gp_simulate, gp_guardrails, gp_blast_radius) plus stdio server (lazy MCP SDK import behind the [mcp] extra). Tool functions are independently callable without the SDK.
- **gp claude-md** — writes/refreshes a marker-delimited '## Graphify-Plus' section inside the **target repo's** CLAUDE.md. Idempotent. Preserves all human-authored content outside the markers. Markers: `<!-- graphify-plus:start -->` / `<!-- graphify-plus:end -->`.
- **gp mcp** subcommand wires the MCP server into the dispatcher.
- pyproject.toml version → 4.0.0.
- CHANGELOG.md captures every phase from v3.1.1 through v4.0.0.

## Tests
199 passed (+10 new). Determinism preserved. Lint + format clean on the Phase 0+ scope.

## Operational invariant (every phase observed it)
Generated artefacts (STAGING_PLAN.md, drift_report.md, visuals, generated tests, CLAUDE.md section, etc.) write into the **target repo at runtime**, never into the graphify-plus tool's own tree.

## Next on merge (manual)
```
git tag -a v4.0.0 -m 'v4.0.0 — universal context & execution engine'
git push origin v4.0.0
```
PyPI publish workflow (release.yml) is **not** in this PR — add it as a separate change before tagging if you want OIDC trusted publishing on the v4.0.0 tag.

## Phases shipped (v3.1.1 → v4.0.0)
- 0 Tree-sitter universal frontend + SQLite cache
- 1 Skeletonizer + content-addressed store
- 2 Live AST watcher + delta-memory sessions
- 3 Topological partition + token-budgeted framing
- 4 Semantic neighbourhood + ghost prune
- 5 STAGING_PLAN manifest + sync-docs daemon (v3.5.0 tagged)
- 6 Unified constraint engine (shadow/guardrails/drift)
- 7 Cross-boundary meta-graph + multi-agent orchestrator
- 8 Git/telemetry/lockfile/blast-radius enrichment + privacy filter
- 9 Edge-centric test scaffolds + visual SVG/PNG/DOT
- 10 MCP server + CLAUDE.md auto-gen (this PR)