### PR TITLE
feat(phase-11): v4.2.0 — confidence layer, regression corpus, doc verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,8 @@ jobs:
         # out of Phase 0 scope and will be brought under lint as later
         # phases refactor them.
         run: |
-          ruff check graphify_plus/core graphify_plus/runtime graphify_plus/interface graphify_plus/query scripts tests/core tests/runtime tests/interface tests/query
-          ruff format --check graphify_plus/core graphify_plus/runtime graphify_plus/interface graphify_plus/query scripts tests/core tests/runtime tests/interface tests/query
+          ruff check graphify_plus/core graphify_plus/runtime graphify_plus/interface graphify_plus/query scripts tests/core tests/runtime tests/interface tests/query tests/regression tests/scripts
+          ruff format --check graphify_plus/core graphify_plus/runtime graphify_plus/interface graphify_plus/query scripts tests/core tests/runtime tests/interface tests/query tests/regression tests/scripts
       - name: Type check
         run: mypy graphify_plus
         continue-on-error: true   # tighten in later phases
@@ -40,5 +40,11 @@ jobs:
           python -m graphify_plus init --repo tests/fixtures/sample_repo --print > /tmp/a.jsonl
           python -m graphify_plus init --repo tests/fixtures/sample_repo --print > /tmp/b.jsonl
           cmp /tmp/a.jsonl /tmp/b.jsonl
+      - name: Doc verification (informational)
+        # README contains many illustrative blocks that aren't designed
+        # to run end-to-end. Until they are audited and either skipped
+        # via <!-- doctest:skip --> or made self-contained, this job
+        # surfaces results without blocking CI.
+        run: python scripts/test_readme.py || true
       - name: Perf baseline
         run: python scripts/perf_bench.py --baseline

--- a/graphify_plus/core/adapters/_generic.py
+++ b/graphify_plus/core/adapters/_generic.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 from tree_sitter_languages import get_parser  # type: ignore[import-untyped]
 
-from .base import Edge, Symbol, make_symbol_id
+from .base import CONF_EXACT, CONF_FALLBACK, Edge, Symbol, make_symbol_id
 
 
 def _text(node, source: bytes) -> str:
@@ -93,6 +93,7 @@ def parse_generic(spec: LangSpec, path: Path, source: bytes) -> tuple[list[Symbo
                     kind="imports",
                     resolved=False,
                     span=(node.start_point[0] + 1, node.end_point[0] + 1),
+                    confidence=CONF_FALLBACK,
                 )
             )
             return
@@ -121,7 +122,14 @@ def parse_generic(spec: LangSpec, path: Path, source: bytes) -> tuple[list[Symbo
                 )
                 if parent_id is not None:
                     edges.append(
-                        Edge(src=parent_id, dst=sid, kind="contains", resolved=True, span=None)
+                        Edge(
+                            src=parent_id,
+                            dst=sid,
+                            kind="contains",
+                            resolved=True,
+                            span=None,
+                            confidence=CONF_EXACT,
+                        )
                     )
                 # recurse into class-likes for methods
                 if kind == "class":

--- a/graphify_plus/core/adapters/_ts_common.py
+++ b/graphify_plus/core/adapters/_ts_common.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from tree_sitter_languages import get_parser  # type: ignore[import-untyped]
 
-from .base import Edge, Symbol, make_symbol_id
+from .base import CONF_EXACT, CONF_FALLBACK, Edge, Symbol, make_symbol_id
 
 
 def _text(node, source: bytes) -> str:
@@ -88,7 +88,16 @@ def parse_ts_like(
             )
         )
         if parent_id is not None:
-            edges.append(Edge(src=parent_id, dst=sid, kind="contains", resolved=True, span=None))
+            edges.append(
+                Edge(
+                    src=parent_id,
+                    dst=sid,
+                    kind="contains",
+                    resolved=True,
+                    span=None,
+                    confidence=CONF_EXACT,
+                )
+            )
         return sid
 
     def walk(node, parent_qname: str, parent_id: str | None) -> None:
@@ -138,7 +147,14 @@ def parse_ts_like(
                                 )
                             )
                             edges.append(
-                                Edge(src=cid, dst=mid, kind="contains", resolved=True, span=None)
+                                Edge(
+                                    src=cid,
+                                    dst=mid,
+                                    kind="contains",
+                                    resolved=True,
+                                    span=None,
+                                    confidence=CONF_EXACT,
+                                )
                             )
             return
 
@@ -164,6 +180,7 @@ def parse_ts_like(
                     kind="imports",
                     resolved=False,
                     span=(node.start_point[0] + 1, node.end_point[0] + 1),
+                    confidence=CONF_FALLBACK,
                 )
             )
             return

--- a/graphify_plus/core/adapters/base.py
+++ b/graphify_plus/core/adapters/base.py
@@ -51,11 +51,11 @@ class Symbol(TypedDict, total=False):
 
 # Confidence defaults per edge source. Consumed by 11.7 (audit probes),
 # 11.8 (telemetry buckets), 11.10 (gp explain), 12.4 (feedback loop).
-CONF_EXACT: float = 1.0       # Tree-sitter structural (contains/defines)
-CONF_RESOLVED: float = 0.7    # import / extends with target found
-CONF_STITCH: float = 0.5      # cross-language stitch
-CONF_INFERRED: float = 0.4    # telemetry / community-inferred / lockfile
-CONF_FALLBACK: float = 0.2    # unresolved heuristic
+CONF_EXACT: float = 1.0  # Tree-sitter structural (contains/defines)
+CONF_RESOLVED: float = 0.7  # import / extends with target found
+CONF_STITCH: float = 0.5  # cross-language stitch
+CONF_INFERRED: float = 0.4  # telemetry / community-inferred / lockfile
+CONF_FALLBACK: float = 0.2  # unresolved heuristic
 
 
 class Edge(TypedDict, total=False):

--- a/graphify_plus/core/adapters/base.py
+++ b/graphify_plus/core/adapters/base.py
@@ -49,12 +49,22 @@ class Symbol(TypedDict, total=False):
     language: str
 
 
+# Confidence defaults per edge source. Consumed by 11.7 (audit probes),
+# 11.8 (telemetry buckets), 11.10 (gp explain), 12.4 (feedback loop).
+CONF_EXACT: float = 1.0       # Tree-sitter structural (contains/defines)
+CONF_RESOLVED: float = 0.7    # import / extends with target found
+CONF_STITCH: float = 0.5      # cross-language stitch
+CONF_INFERRED: float = 0.4    # telemetry / community-inferred / lockfile
+CONF_FALLBACK: float = 0.2    # unresolved heuristic
+
+
 class Edge(TypedDict, total=False):
     src: str
     dst: str
     kind: EdgeKind
     resolved: bool
     span: tuple[int, int] | None
+    confidence: float
 
 
 def make_symbol_id(path: str, qualified_name: str) -> str:

--- a/graphify_plus/core/adapters/python_adapter.py
+++ b/graphify_plus/core/adapters/python_adapter.py
@@ -178,7 +178,14 @@ class PythonAdapter:
                 )
                 if parent_id is not None:
                     edges.append(
-                        Edge(src=parent_id, dst=cid, kind="contains", resolved=True, span=None)
+                        Edge(
+                            src=parent_id,
+                            dst=cid,
+                            kind="contains",
+                            resolved=True,
+                            span=None,
+                            confidence=CONF_EXACT,
+                        )
                     )
                 for base in base_strs:
                     edges.append(

--- a/graphify_plus/core/adapters/python_adapter.py
+++ b/graphify_plus/core/adapters/python_adapter.py
@@ -8,7 +8,15 @@ from typing import ClassVar
 # tree_sitter_languages is the bundled-grammar shim.
 from tree_sitter_languages import get_parser  # type: ignore[import-untyped]
 
-from .base import Edge, LangAdapter, Symbol, make_symbol_id
+from .base import (
+    CONF_EXACT,
+    CONF_FALLBACK,
+    CONF_RESOLVED,
+    Edge,
+    LangAdapter,
+    Symbol,
+    make_symbol_id,
+)
 
 
 def _text(node, source: bytes) -> str:
@@ -122,7 +130,14 @@ class PythonAdapter:
                 )
                 if parent_id is not None:
                     edges.append(
-                        Edge(src=parent_id, dst=sid, kind="contains", resolved=True, span=None)
+                        Edge(
+                            src=parent_id,
+                            dst=sid,
+                            kind="contains",
+                            resolved=True,
+                            span=None,
+                            confidence=CONF_EXACT,
+                        )
                     )
                 # walk body for calls
                 _collect_calls(body, sid)
@@ -166,7 +181,16 @@ class PythonAdapter:
                         Edge(src=parent_id, dst=cid, kind="contains", resolved=True, span=None)
                     )
                 for base in base_strs:
-                    edges.append(Edge(src=cid, dst=base, kind="extends", resolved=False, span=None))
+                    edges.append(
+                        Edge(
+                            src=cid,
+                            dst=base,
+                            kind="extends",
+                            resolved=False,
+                            span=None,
+                            confidence=CONF_FALLBACK,
+                        )
+                    )
                 if body is not None:
                     for ch in body.children:
                         walk(ch, qname, cid)
@@ -181,6 +205,7 @@ class PythonAdapter:
                         kind="imports",
                         resolved=False,
                         span=(node.start_point[0] + 1, node.end_point[0] + 1),
+                        confidence=CONF_FALLBACK,
                     )
                 )
                 return
@@ -229,6 +254,7 @@ class PythonAdapter:
                                 kind="calls",
                                 resolved=False,
                                 span=(n.start_point[0] + 1, n.end_point[0] + 1),
+                                confidence=CONF_FALLBACK,
                             )
                         )
                 for ch in n.children:
@@ -245,7 +271,14 @@ class PythonAdapter:
                 if sym["name"] in all_exports:
                     sym["exported"] = True
                     edges.append(
-                        Edge(src=module_id, dst=sym["id"], kind="exports", resolved=True, span=None)
+                        Edge(
+                            src=module_id,
+                            dst=sym["id"],
+                            kind="exports",
+                            resolved=True,
+                            span=None,
+                            confidence=CONF_RESOLVED,
+                        )
                     )
 
         # Deterministic sort

--- a/graphify_plus/core/symbol_graph.py
+++ b/graphify_plus/core/symbol_graph.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import networkx as nx
 
 from .adapters import Edge, Symbol
+from .adapters.base import CONF_FALLBACK
 
 
 def build(symbols: list[Symbol], edges: list[Edge]) -> nx.MultiDiGraph:
@@ -49,6 +50,7 @@ def build(symbols: list[Symbol], edges: list[Edge]) -> nx.MultiDiGraph:
             kind=e.get("kind"),
             resolved=bool(e.get("resolved")),
             span=e.get("span"),
+            confidence=float(e.get("confidence", CONF_FALLBACK)),
         )
     return G
 

--- a/graphify_plus/interface/cli/claude_md_cmd.py
+++ b/graphify_plus/interface/cli/claude_md_cmd.py
@@ -30,7 +30,7 @@ from ...runtime.store import Store, cache_path
 
 START_MARKER = "<!-- graphify-plus:start -->"
 END_MARKER = "<!-- graphify-plus:end -->"
-TEMPLATE_VERSION = 1
+TEMPLATE_VERSION = 2
 
 
 def _detect_stack(symbols) -> list[str]:
@@ -108,6 +108,16 @@ def render_section(repo: Path) -> str:
         "never into the graphify-plus tool's own source tree."
     )
     lines.append("")
+    lines.extend(
+        [
+            "### Edge confidence",
+            "",
+            "When confidence < 0.7 on any edge in your context output, verify by "
+            "reading the source file directly before relying on it. Low-confidence "
+            "edges are heuristic guesses, not facts.",
+            "",
+        ]
+    )
     lines.append(END_MARKER)
     return "\n".join(lines) + "\n"
 

--- a/graphify_plus/interface/cli/context_cmd.py
+++ b/graphify_plus/interface/cli/context_cmd.py
@@ -82,6 +82,13 @@ def _resolve_target(store: Store, target: str) -> str:
     is_flag=True,
     help="Implies --apply-prune; also excludes deprecated symbols.",
 )
+@click.option(
+    "--min-confidence",
+    "min_confidence",
+    type=float,
+    default=0.0,
+    help="Drop edges with confidence < this threshold (0.0 = keep all).",
+)
 def context_cmd(
     repo: Path,
     entry: str | None,
@@ -90,6 +97,7 @@ def context_cmd(
     json_manifest: bool,
     apply_prune: bool,
     aggressive_prune: bool,
+    min_confidence: float,
 ) -> None:
     """Print a token-budgeted slice of the symbol graph."""
     repo = repo.resolve()
@@ -103,6 +111,8 @@ def context_cmd(
         entry_id = _resolve_entry(store, entry, target_id)
         symbols = store.all_symbols()
         edges = store.all_edges()
+        if min_confidence > 0.0:
+            edges = [e for e in edges if float(e.get("confidence", 0.2)) >= min_confidence]
         G = build_graph(symbols, edges)
         try:
             partition = compute_partition(G, entry_id, target_id)

--- a/scripts/regen_corpus_baselines.py
+++ b/scripts/regen_corpus_baselines.py
@@ -1,0 +1,44 @@
+"""Regenerate ``tests/fixtures/regression_corpus/baselines.json``.
+
+Run this whenever an intentional adapter change lands. CI does not run
+it — review the diff manually before committing.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from graphify_plus.core.adapters import adapter_for
+
+CORPUS_ROOT = Path(__file__).resolve().parent.parent / "tests" / "fixtures" / "regression_corpus"
+BASELINES = CORPUS_ROOT / "baselines.json"
+
+
+def _baseline_for_language(lang_dir: Path) -> dict[str, dict[str, int]]:
+    out: dict[str, dict[str, int]] = {}
+    for f in sorted(lang_dir.iterdir()):
+        if not f.is_file() or f.suffix == ".md":
+            continue
+        adapter = adapter_for(f.name)
+        if adapter is None:
+            continue
+        symbols, edges = adapter.parse(f, f.read_bytes())
+        out[f.name] = {"symbols": len(symbols), "edges": len(edges)}
+    return out
+
+
+def main() -> None:
+    result: dict[str, dict[str, dict[str, int]]] = {}
+    for lang_dir in sorted(CORPUS_ROOT.iterdir()):
+        if not lang_dir.is_dir():
+            continue
+        baseline = _baseline_for_language(lang_dir)
+        if baseline:
+            result[lang_dir.name] = baseline
+    BASELINES.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n")
+    print(f"wrote {BASELINES}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_readme.py
+++ b/scripts/test_readme.py
@@ -1,0 +1,73 @@
+"""11.9 — README doc verification.
+
+Walks ``README.md`` (and any other docs added in future), extracts every
+fenced ``bash``/``sh`` block, and runs each block in a subprocess in a
+fresh temp directory. A block prefixed by ``<!-- doctest:skip -->`` on
+the line immediately above is skipped.
+
+Exit 0 if every executed block returns 0; non-zero otherwise.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+DOCS = [ROOT / "README.md"]
+
+FENCE_RE = re.compile(
+    r"(?P<skip><!-- doctest:skip -->\s*\n)?"
+    r"```(?P<lang>bash|sh)\n(?P<body>.*?)\n```",
+    re.DOTALL,
+)
+
+
+def extract_blocks(text: str) -> list[tuple[int, str]]:
+    out: list[tuple[int, str]] = []
+    for m in FENCE_RE.finditer(text):
+        if m.group("skip"):
+            continue
+        line = text.count("\n", 0, m.start()) + 1
+        out.append((line, m.group("body")))
+    return out
+
+
+def run_block(body: str, cwd: Path) -> tuple[int, str, str]:
+    proc = subprocess.run(
+        ["bash", "-eu", "-o", "pipefail", "-c", body],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def main() -> int:
+    failures = 0
+    for doc in DOCS:
+        if not doc.exists():
+            continue
+        text = doc.read_text()
+        for line, body in extract_blocks(text):
+            with tempfile.TemporaryDirectory() as td:
+                rc, _out, err = run_block(body, Path(td))
+            if rc != 0:
+                failures += 1
+                print(
+                    f"FAIL {doc.name}:{line} (exit {rc})\n--- block ---\n{body}\n--- stderr ---\n{err}\n"
+                )
+            else:
+                print(f"OK   {doc.name}:{line}")
+    if failures:
+        print(f"\n{failures} block(s) failed", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/core/test_confidence.py
+++ b/tests/core/test_confidence.py
@@ -1,0 +1,68 @@
+"""11.2 — confidence layer: every adapter emits ``confidence`` per edge."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from graphify_plus.core.adapters.base import (
+    CONF_EXACT,
+    CONF_FALLBACK,
+    CONF_RESOLVED,
+)
+from graphify_plus.core.adapters.python_adapter import PythonAdapter
+from graphify_plus.core.adapters.typescript_adapter import TypeScriptAdapter
+from graphify_plus.core.adapters.go_adapter import GoAdapter
+
+
+def _confidences_by_kind(edges):
+    out: dict[str, set[float]] = {}
+    for e in edges:
+        out.setdefault(e["kind"], set()).add(e.get("confidence"))
+    return out
+
+
+def test_python_adapter_emits_confidence_per_edge_kind():
+    src = b"""
+import os
+from foo import bar
+
+class Cat(Animal):
+    def meow(self):
+        return os.path.join("a", "b")
+
+__all__ = ["Cat"]
+"""
+    syms, edges = PythonAdapter().parse(Path("cat.py"), src)
+    assert all("confidence" in e for e in edges), "every edge must carry confidence"
+    by_kind = _confidences_by_kind(edges)
+    assert by_kind["contains"] == {CONF_EXACT}
+    assert by_kind["imports"] == {CONF_FALLBACK}
+    assert by_kind["extends"] == {CONF_FALLBACK}
+    assert by_kind["calls"] == {CONF_FALLBACK}
+    assert by_kind["exports"] == {CONF_RESOLVED}
+
+
+def test_typescript_adapter_emits_confidence():
+    src = b"""
+import {x} from 'foo';
+export class C {
+  m() {}
+}
+"""
+    _syms, edges = TypeScriptAdapter().parse(Path("a.ts"), src)
+    assert all("confidence" in e for e in edges)
+    by_kind = _confidences_by_kind(edges)
+    assert by_kind.get("contains") == {CONF_EXACT}
+    assert by_kind.get("imports") == {CONF_FALLBACK}
+
+
+def test_go_adapter_emits_confidence():
+    src = b"""package main
+import "fmt"
+type Cat struct{}
+func (c Cat) Meow() { fmt.Println("hi") }
+"""
+    _syms, edges = GoAdapter().parse(Path("cat.go"), src)
+    assert all("confidence" in e for e in edges)
+    by_kind = _confidences_by_kind(edges)
+    assert by_kind.get("imports") == {CONF_FALLBACK}

--- a/tests/core/test_confidence.py
+++ b/tests/core/test_confidence.py
@@ -9,9 +9,9 @@ from graphify_plus.core.adapters.base import (
     CONF_FALLBACK,
     CONF_RESOLVED,
 )
+from graphify_plus.core.adapters.go_adapter import GoAdapter
 from graphify_plus.core.adapters.python_adapter import PythonAdapter
 from graphify_plus.core.adapters.typescript_adapter import TypeScriptAdapter
-from graphify_plus.core.adapters.go_adapter import GoAdapter
 
 
 def _confidences_by_kind(edges):

--- a/tests/core/test_symbol_graph_confidence.py
+++ b/tests/core/test_symbol_graph_confidence.py
@@ -23,7 +23,9 @@ def test_build_propagates_confidence_to_edge_attrs():
     sym_b: Symbol = {**sym_a, "id": "b", "qualified_name": "b", "name": "b"}
     edges: list[Edge] = [
         Edge(src="a", dst="b", kind="contains", resolved=True, span=None, confidence=CONF_EXACT),
-        Edge(src="a", dst="ext", kind="imports", resolved=False, span=None, confidence=CONF_FALLBACK),
+        Edge(
+            src="a", dst="ext", kind="imports", resolved=False, span=None, confidence=CONF_FALLBACK
+        ),
     ]
     g = build([sym_a, sym_b], edges)
     confidences = sorted(d["confidence"] for _u, _v, _k, d in g.edges(data=True, keys=True))

--- a/tests/core/test_symbol_graph_confidence.py
+++ b/tests/core/test_symbol_graph_confidence.py
@@ -1,0 +1,50 @@
+"""Confidence propagation through ``symbol_graph.build``."""
+
+from __future__ import annotations
+
+from graphify_plus.core.adapters.base import CONF_EXACT, CONF_FALLBACK, Edge, Symbol
+from graphify_plus.core.symbol_graph import build
+
+
+def test_build_propagates_confidence_to_edge_attrs():
+    sym_a: Symbol = {
+        "id": "a",
+        "kind": "module",
+        "name": "a",
+        "qualified_name": "a",
+        "path": "a.py",
+        "span": (0, 0),
+        "signature": "",
+        "exported": True,
+        "docstring": None,
+        "parent_id": None,
+        "language": "python",
+    }
+    sym_b: Symbol = {**sym_a, "id": "b", "qualified_name": "b", "name": "b"}
+    edges: list[Edge] = [
+        Edge(src="a", dst="b", kind="contains", resolved=True, span=None, confidence=CONF_EXACT),
+        Edge(src="a", dst="ext", kind="imports", resolved=False, span=None, confidence=CONF_FALLBACK),
+    ]
+    g = build([sym_a, sym_b], edges)
+    confidences = sorted(d["confidence"] for _u, _v, _k, d in g.edges(data=True, keys=True))
+    assert confidences == [CONF_FALLBACK, CONF_EXACT]
+
+
+def test_build_defaults_missing_confidence_to_fallback():
+    sym: Symbol = {
+        "id": "a",
+        "kind": "module",
+        "name": "a",
+        "qualified_name": "a",
+        "path": "a.py",
+        "span": (0, 0),
+        "signature": "",
+        "exported": True,
+        "docstring": None,
+        "parent_id": None,
+        "language": "python",
+    }
+    legacy: Edge = {"src": "a", "dst": "x", "kind": "imports", "resolved": False, "span": None}
+    g = build([sym], [legacy])
+    _u, _v, _k, d = next(iter(g.edges(data=True, keys=True)))
+    assert d["confidence"] == CONF_FALLBACK

--- a/tests/fixtures/regression_corpus/CONTRIBUTING.md
+++ b/tests/fixtures/regression_corpus/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+# Expanding the regression corpus
+
+This corpus catches accidental regressions in adapter parsing — adding,
+removing, or renaming a single symbol or edge in any file flips a test.
+
+## Adding files
+
+1. Drop a new file under the matching language directory. Keep it small
+   (under ~30 lines) and self-contained — exercise **one** language
+   feature per file (e.g. `06_pattern_matching.py`, not a kitchen-sink).
+2. Prefer original code over copying. If you must derive from an
+   upstream open-source file, record it in `SOURCES.md` with license +
+   SPDX identifier.
+3. Regenerate baselines with:
+   ```
+   python -m scripts.regen_corpus_baselines
+   ```
+   Review the diff in `baselines.json` carefully — it's the contract.
+4. Commit corpus + baseline changes together.
+
+## Eventual target
+
+The full RESILIENCE_PLAN target is ≥30 files per language (~240 total).
+v4.2.0 ships a 5-file-per-language starter; growth happens incrementally
+in subsequent PRs.

--- a/tests/fixtures/regression_corpus/SOURCES.md
+++ b/tests/fixtures/regression_corpus/SOURCES.md
@@ -1,0 +1,19 @@
+# Regression corpus — sources & attribution
+
+Each language directory has 5 files exercising representative shapes:
+classes, interfaces / traits, generics, async / concurrency, modules,
+inheritance, decorators, enums, records.
+
+All files in this corpus are **original test fixtures authored for the
+graphify-plus project** by its maintainers. They are not copied or
+adapted from third-party projects, so no upstream attribution is
+required.
+
+If a future expansion of this corpus introduces files derived from
+external open-source projects (recommended for catching real-world
+parser quirks), record each here as:
+
+| File | Source URL | License | SPDX | Adapted? |
+|------|------------|---------|------|----------|
+
+(table empty until expansion lands).

--- a/tests/fixtures/regression_corpus/baselines.json
+++ b/tests/fixtures/regression_corpus/baselines.json
@@ -1,0 +1,178 @@
+{
+  "csharp": {
+    "01_class.cs": {
+      "edges": 2,
+      "symbols": 3
+    },
+    "02_interface.cs": {
+      "edges": 2,
+      "symbols": 3
+    },
+    "03_inheritance.cs": {
+      "edges": 3,
+      "symbols": 4
+    },
+    "04_generic.cs": {
+      "edges": 2,
+      "symbols": 3
+    },
+    "05_record.cs": {
+      "edges": 2,
+      "symbols": 3
+    }
+  },
+  "go": {
+    "01_struct.go": {
+      "edges": 1,
+      "symbols": 2
+    },
+    "02_interface.go": {
+      "edges": 2,
+      "symbols": 2
+    },
+    "03_generic.go": {
+      "edges": 2,
+      "symbols": 3
+    },
+    "04_channels.go": {
+      "edges": 2,
+      "symbols": 3
+    },
+    "05_errors.go": {
+      "edges": 2,
+      "symbols": 2
+    }
+  },
+  "java": {
+    "01_class.java": {
+      "edges": 2,
+      "symbols": 3
+    },
+    "02_interface.java": {
+      "edges": 2,
+      "symbols": 3
+    },
+    "03_inheritance.java": {
+      "edges": 3,
+      "symbols": 4
+    },
+    "04_generic.java": {
+      "edges": 5,
+      "symbols": 4
+    },
+    "05_enum.java": {
+      "edges": 2,
+      "symbols": 3
+    }
+  },
+  "javascript": {
+    "01_function.js": {
+      "edges": 2,
+      "symbols": 3
+    },
+    "02_class.js": {
+      "edges": 3,
+      "symbols": 4
+    },
+    "03_inheritance.js": {
+      "edges": 3,
+      "symbols": 3
+    },
+    "04_async.js": {
+      "edges": 1,
+      "symbols": 2
+    },
+    "05_jsx.jsx": {
+      "edges": 2,
+      "symbols": 2
+    }
+  },
+  "python": {
+    "01_simple_class.py": {
+      "edges": 3,
+      "symbols": 4
+    },
+    "02_inheritance.py": {
+      "edges": 10,
+      "symbols": 6
+    },
+    "03_decorators.py": {
+      "edges": 7,
+      "symbols": 3
+    },
+    "04_async.py": {
+      "edges": 5,
+      "symbols": 3
+    },
+    "05_dataclass.py": {
+      "edges": 3,
+      "symbols": 3
+    }
+  },
+  "ruby": {
+    "01_class.rb": {
+      "edges": 3,
+      "symbols": 4
+    },
+    "02_module.rb": {
+      "edges": 4,
+      "symbols": 5
+    },
+    "03_inheritance.rb": {
+      "edges": 4,
+      "symbols": 5
+    },
+    "04_blocks.rb": {
+      "edges": 2,
+      "symbols": 3
+    },
+    "05_singleton.rb": {
+      "edges": 2,
+      "symbols": 3
+    }
+  },
+  "rust": {
+    "01_struct.rs": {
+      "edges": 4,
+      "symbols": 5
+    },
+    "02_trait.rs": {
+      "edges": 4,
+      "symbols": 5
+    },
+    "03_enum.rs": {
+      "edges": 3,
+      "symbols": 4
+    },
+    "04_generic.rs": {
+      "edges": 2,
+      "symbols": 3
+    },
+    "05_module.rs": {
+      "edges": 2,
+      "symbols": 2
+    }
+  },
+  "typescript": {
+    "01_class.ts": {
+      "edges": 3,
+      "symbols": 4
+    },
+    "02_interface.ts": {
+      "edges": 3,
+      "symbols": 4
+    },
+    "03_generic.ts": {
+      "edges": 4,
+      "symbols": 4
+    },
+    "04_async.ts": {
+      "edges": 1,
+      "symbols": 2
+    },
+    "05_decorator.ts": {
+      "edges": 3,
+      "symbols": 4
+    }
+  }
+}

--- a/tests/fixtures/regression_corpus/csharp/01_class.cs
+++ b/tests/fixtures/regression_corpus/csharp/01_class.cs
@@ -1,0 +1,6 @@
+namespace Corpus;
+
+public class Counter {
+    private int n;
+    public int Inc() => ++n;
+}

--- a/tests/fixtures/regression_corpus/csharp/02_interface.cs
+++ b/tests/fixtures/regression_corpus/csharp/02_interface.cs
@@ -1,0 +1,5 @@
+namespace Corpus;
+
+public interface ISpeak {
+    string Speak();
+}

--- a/tests/fixtures/regression_corpus/csharp/03_inheritance.cs
+++ b/tests/fixtures/regression_corpus/csharp/03_inheritance.cs
@@ -1,0 +1,7 @@
+namespace Corpus;
+
+public class Dog : ISpeak {
+    private readonly string name;
+    public Dog(string name) { this.name = name; }
+    public string Speak() => $"{name} barks";
+}

--- a/tests/fixtures/regression_corpus/csharp/04_generic.cs
+++ b/tests/fixtures/regression_corpus/csharp/04_generic.cs
@@ -1,0 +1,7 @@
+namespace Corpus;
+
+public class Box<T> {
+    private readonly System.Collections.Generic.List<T> items = new();
+    public void Add(T v) => items.Add(v);
+    public int Count => items.Count;
+}

--- a/tests/fixtures/regression_corpus/csharp/05_record.cs
+++ b/tests/fixtures/regression_corpus/csharp/05_record.cs
@@ -1,0 +1,5 @@
+namespace Corpus;
+
+public record Point(double X, double Y) {
+    public double Magnitude() => System.Math.Sqrt(X * X + Y * Y);
+}

--- a/tests/fixtures/regression_corpus/go/01_struct.go
+++ b/tests/fixtures/regression_corpus/go/01_struct.go
@@ -1,0 +1,5 @@
+package main
+
+type Counter struct{ n int }
+
+func (c *Counter) Inc() int { c.n++; return c.n }

--- a/tests/fixtures/regression_corpus/go/02_interface.go
+++ b/tests/fixtures/regression_corpus/go/02_interface.go
@@ -1,0 +1,9 @@
+package main
+
+import "fmt"
+
+type Animal interface{ Speak() string }
+
+type Dog struct{ Name string }
+
+func (d Dog) Speak() string { return fmt.Sprintf("%s barks", d.Name) }

--- a/tests/fixtures/regression_corpus/go/03_generic.go
+++ b/tests/fixtures/regression_corpus/go/03_generic.go
@@ -1,0 +1,7 @@
+package main
+
+type List[T any] struct{ items []T }
+
+func (l *List[T]) Add(v T) { l.items = append(l.items, v) }
+
+func (l *List[T]) Len() int { return len(l.items) }

--- a/tests/fixtures/regression_corpus/go/04_channels.go
+++ b/tests/fixtures/regression_corpus/go/04_channels.go
@@ -1,0 +1,16 @@
+package main
+
+func produce(c chan<- int) {
+	for i := 0; i < 3; i++ {
+		c <- i
+	}
+	close(c)
+}
+
+func sum(c <-chan int) int {
+	total := 0
+	for v := range c {
+		total += v
+	}
+	return total
+}

--- a/tests/fixtures/regression_corpus/go/05_errors.go
+++ b/tests/fixtures/regression_corpus/go/05_errors.go
@@ -1,0 +1,12 @@
+package main
+
+import "errors"
+
+var ErrNotFound = errors.New("not found")
+
+func Lookup(id int) (string, error) {
+	if id == 0 {
+		return "", ErrNotFound
+	}
+	return "ok", nil
+}

--- a/tests/fixtures/regression_corpus/java/01_class.java
+++ b/tests/fixtures/regression_corpus/java/01_class.java
@@ -1,0 +1,6 @@
+package corpus;
+
+public class Counter {
+    private int n;
+    public int inc() { return ++n; }
+}

--- a/tests/fixtures/regression_corpus/java/02_interface.java
+++ b/tests/fixtures/regression_corpus/java/02_interface.java
@@ -1,0 +1,5 @@
+package corpus;
+
+public interface Speak {
+    String speak();
+}

--- a/tests/fixtures/regression_corpus/java/03_inheritance.java
+++ b/tests/fixtures/regression_corpus/java/03_inheritance.java
@@ -1,0 +1,7 @@
+package corpus;
+
+public class Dog implements Speak {
+    private final String name;
+    public Dog(String name) { this.name = name; }
+    public String speak() { return name + " barks"; }
+}

--- a/tests/fixtures/regression_corpus/java/04_generic.java
+++ b/tests/fixtures/regression_corpus/java/04_generic.java
@@ -1,0 +1,10 @@
+package corpus;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Box<T> {
+    private final List<T> items = new ArrayList<>();
+    public void add(T v) { items.add(v); }
+    public int size() { return items.size(); }
+}

--- a/tests/fixtures/regression_corpus/java/05_enum.java
+++ b/tests/fixtures/regression_corpus/java/05_enum.java
@@ -1,0 +1,6 @@
+package corpus;
+
+public enum Color {
+    RED, GREEN, BLUE;
+    public boolean isWarm() { return this == RED; }
+}

--- a/tests/fixtures/regression_corpus/javascript/01_function.js
+++ b/tests/fixtures/regression_corpus/javascript/01_function.js
@@ -1,0 +1,2 @@
+export function add(a, b) { return a + b; }
+export const sub = (a, b) => a - b;

--- a/tests/fixtures/regression_corpus/javascript/02_class.js
+++ b/tests/fixtures/regression_corpus/javascript/02_class.js
@@ -1,0 +1,4 @@
+export class Animal {
+  constructor(name) { this.name = name; }
+  speak() { return `${this.name} makes a sound`; }
+}

--- a/tests/fixtures/regression_corpus/javascript/03_inheritance.js
+++ b/tests/fixtures/regression_corpus/javascript/03_inheritance.js
@@ -1,0 +1,4 @@
+import { Animal } from "./02_class";
+export class Dog extends Animal {
+  speak() { return `${this.name} barks`; }
+}

--- a/tests/fixtures/regression_corpus/javascript/04_async.js
+++ b/tests/fixtures/regression_corpus/javascript/04_async.js
@@ -1,0 +1,4 @@
+export async function load(url) {
+  const r = await fetch(url);
+  return r.json();
+}

--- a/tests/fixtures/regression_corpus/javascript/05_jsx.jsx
+++ b/tests/fixtures/regression_corpus/javascript/05_jsx.jsx
@@ -1,0 +1,4 @@
+import React from "react";
+export function Button({ label }) {
+  return <button>{label}</button>;
+}

--- a/tests/fixtures/regression_corpus/python/01_simple_class.py
+++ b/tests/fixtures/regression_corpus/python/01_simple_class.py
@@ -1,0 +1,7 @@
+class Counter:
+    def __init__(self):
+        self.n = 0
+
+    def inc(self):
+        self.n += 1
+        return self.n

--- a/tests/fixtures/regression_corpus/python/02_inheritance.py
+++ b/tests/fixtures/regression_corpus/python/02_inheritance.py
@@ -1,0 +1,18 @@
+import abc
+
+
+class Shape(abc.ABC):
+    @abc.abstractmethod
+    def area(self):
+        ...
+
+
+class Circle(Shape):
+    def __init__(self, r):
+        self.r = r
+
+    def area(self):
+        return 3.14 * self.r * self.r
+
+
+__all__ = ["Shape", "Circle"]

--- a/tests/fixtures/regression_corpus/python/03_decorators.py
+++ b/tests/fixtures/regression_corpus/python/03_decorators.py
@@ -1,0 +1,13 @@
+import functools
+
+
+def cached(fn):
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        return fn(*args, **kwargs)
+    return wrapper
+
+
+@cached
+def fib(n):
+    return n if n < 2 else fib(n - 1) + fib(n - 2)

--- a/tests/fixtures/regression_corpus/python/04_async.py
+++ b/tests/fixtures/regression_corpus/python/04_async.py
@@ -1,0 +1,10 @@
+import asyncio
+
+
+async def fetch(url):
+    await asyncio.sleep(0)
+    return url
+
+
+async def main():
+    return await fetch("a")

--- a/tests/fixtures/regression_corpus/python/05_dataclass.py
+++ b/tests/fixtures/regression_corpus/python/05_dataclass.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Point:
+    x: float
+    y: float
+
+    def magnitude(self):
+        return (self.x ** 2 + self.y ** 2) ** 0.5

--- a/tests/fixtures/regression_corpus/ruby/01_class.rb
+++ b/tests/fixtures/regression_corpus/ruby/01_class.rb
@@ -1,0 +1,9 @@
+class Counter
+  def initialize
+    @n = 0
+  end
+
+  def inc
+    @n += 1
+  end
+end

--- a/tests/fixtures/regression_corpus/ruby/02_module.rb
+++ b/tests/fixtures/regression_corpus/ruby/02_module.rb
@@ -1,0 +1,13 @@
+module Greetable
+  def greet
+    "hello #{name}"
+  end
+end
+
+class Person
+  include Greetable
+  attr_reader :name
+  def initialize(name)
+    @name = name
+  end
+end

--- a/tests/fixtures/regression_corpus/ruby/03_inheritance.rb
+++ b/tests/fixtures/regression_corpus/ruby/03_inheritance.rb
@@ -1,0 +1,11 @@
+class Animal
+  def speak
+    "generic sound"
+  end
+end
+
+class Dog < Animal
+  def speak
+    "bark"
+  end
+end

--- a/tests/fixtures/regression_corpus/ruby/04_blocks.rb
+++ b/tests/fixtures/regression_corpus/ruby/04_blocks.rb
@@ -1,0 +1,5 @@
+class Repeater
+  def repeat(n)
+    n.times { |i| yield i }
+  end
+end

--- a/tests/fixtures/regression_corpus/ruby/05_singleton.rb
+++ b/tests/fixtures/regression_corpus/ruby/05_singleton.rb
@@ -1,0 +1,10 @@
+class Logger
+  @@instance = nil
+  def self.instance
+    @@instance ||= new
+  end
+
+  def log(msg)
+    puts msg
+  end
+end

--- a/tests/fixtures/regression_corpus/rust/01_struct.rs
+++ b/tests/fixtures/regression_corpus/rust/01_struct.rs
@@ -1,0 +1,6 @@
+pub struct Counter { n: u32 }
+
+impl Counter {
+    pub fn new() -> Self { Counter { n: 0 } }
+    pub fn inc(&mut self) -> u32 { self.n += 1; self.n }
+}

--- a/tests/fixtures/regression_corpus/rust/02_trait.rs
+++ b/tests/fixtures/regression_corpus/rust/02_trait.rs
@@ -1,0 +1,7 @@
+pub trait Speak { fn speak(&self) -> String; }
+
+pub struct Dog { pub name: String }
+
+impl Speak for Dog {
+    fn speak(&self) -> String { format!("{} barks", self.name) }
+}

--- a/tests/fixtures/regression_corpus/rust/03_enum.rs
+++ b/tests/fixtures/regression_corpus/rust/03_enum.rs
@@ -1,0 +1,10 @@
+pub enum Shape { Circle(f64), Square(f64) }
+
+impl Shape {
+    pub fn area(&self) -> f64 {
+        match self {
+            Shape::Circle(r) => 3.14 * r * r,
+            Shape::Square(s) => s * s,
+        }
+    }
+}

--- a/tests/fixtures/regression_corpus/rust/04_generic.rs
+++ b/tests/fixtures/regression_corpus/rust/04_generic.rs
@@ -1,0 +1,5 @@
+pub struct Pair<A, B> { pub first: A, pub second: B }
+
+impl<A, B> Pair<A, B> {
+    pub fn new(a: A, b: B) -> Self { Pair { first: a, second: b } }
+}

--- a/tests/fixtures/regression_corpus/rust/05_module.rs
+++ b/tests/fixtures/regression_corpus/rust/05_module.rs
@@ -1,0 +1,9 @@
+use std::collections::HashMap;
+
+pub fn count_chars(s: &str) -> HashMap<char, u32> {
+    let mut out = HashMap::new();
+    for c in s.chars() {
+        *out.entry(c).or_insert(0) += 1;
+    }
+    out
+}

--- a/tests/fixtures/regression_corpus/typescript/01_class.ts
+++ b/tests/fixtures/regression_corpus/typescript/01_class.ts
@@ -1,0 +1,4 @@
+export class Greeter {
+  constructor(private name: string) {}
+  greet(): string { return `hello ${this.name}`; }
+}

--- a/tests/fixtures/regression_corpus/typescript/02_interface.ts
+++ b/tests/fixtures/regression_corpus/typescript/02_interface.ts
@@ -1,0 +1,3 @@
+export interface User { id: number; name: string }
+export type Role = "admin" | "user";
+export function isAdmin(u: User, r: Role): boolean { return r === "admin"; }

--- a/tests/fixtures/regression_corpus/typescript/03_generic.ts
+++ b/tests/fixtures/regression_corpus/typescript/03_generic.ts
@@ -1,0 +1,5 @@
+import { Greeter } from "./01_class";
+export class Box<T> {
+  constructor(public value: T) {}
+  map<U>(fn: (v: T) => U): Box<U> { return new Box(fn(this.value)); }
+}

--- a/tests/fixtures/regression_corpus/typescript/04_async.ts
+++ b/tests/fixtures/regression_corpus/typescript/04_async.ts
@@ -1,0 +1,4 @@
+export async function fetchJson<T>(url: string): Promise<T> {
+  const r = await fetch(url);
+  return r.json();
+}

--- a/tests/fixtures/regression_corpus/typescript/05_decorator.ts
+++ b/tests/fixtures/regression_corpus/typescript/05_decorator.ts
@@ -1,0 +1,5 @@
+function log(_t: any, _k: string, d: PropertyDescriptor) { return d; }
+export class Service {
+  @log
+  run(): number { return 42; }
+}

--- a/tests/interface/test_claude_md_template_v2.py
+++ b/tests/interface/test_claude_md_template_v2.py
@@ -6,7 +6,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-
 CONFIDENCE_PARAGRAPH = (
     "When confidence < 0.7 on any edge in your context output, verify by "
     "reading the source file directly before relying on it. Low-confidence "

--- a/tests/interface/test_claude_md_template_v2.py
+++ b/tests/interface/test_claude_md_template_v2.py
@@ -1,0 +1,33 @@
+"""Template v2 emits the verbatim confidence-warning paragraph."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+CONFIDENCE_PARAGRAPH = (
+    "When confidence < 0.7 on any edge in your context output, verify by "
+    "reading the source file directly before relying on it. Low-confidence "
+    "edges are heuristic guesses, not facts."
+)
+
+
+def test_template_version_marker_is_2_and_warning_present(tmp_path: Path):
+    repo = tmp_path / "sample"
+    repo.mkdir()
+    (repo / "a.py").write_text("def f(): pass\n")
+    subprocess.run(
+        [sys.executable, "-m", "graphify_plus", "init", "--repo", str(repo), "--no-parallel"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        [sys.executable, "-m", "graphify_plus", "claude-md", "--repo", str(repo)],
+        check=True,
+        capture_output=True,
+    )
+    text = (repo / "CLAUDE.md").read_text()
+    assert "<!-- graphify-plus-template-version: 2 -->" in text
+    assert CONFIDENCE_PARAGRAPH in text

--- a/tests/regression/test_corpus.py
+++ b/tests/regression/test_corpus.py
@@ -1,0 +1,39 @@
+"""11.5 — adapter regression corpus.
+
+Each file under ``tests/fixtures/regression_corpus/<lang>/`` parses to a
+fixed (symbols, edges) count recorded in ``baselines.json``. Any drift
+fails CI. To intentionally update the baseline run::
+
+    python scripts/regen_corpus_baselines.py
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from graphify_plus.core.adapters import adapter_for
+
+CORPUS_ROOT = Path(__file__).resolve().parent.parent / "fixtures" / "regression_corpus"
+BASELINES = json.loads((CORPUS_ROOT / "baselines.json").read_text())
+
+
+def _cases():
+    for lang, files in sorted(BASELINES.items()):
+        for fname, expected in sorted(files.items()):
+            yield pytest.param(lang, fname, expected, id=f"{lang}/{fname}")
+
+
+@pytest.mark.parametrize("lang,fname,expected", list(_cases()))
+def test_adapter_baseline(lang: str, fname: str, expected: dict) -> None:
+    f = CORPUS_ROOT / lang / fname
+    adapter = adapter_for(f.name)
+    assert adapter is not None, f"no adapter matches {fname}"
+    symbols, edges = adapter.parse(f, f.read_bytes())
+    actual = {"symbols": len(symbols), "edges": len(edges)}
+    assert actual == expected, (
+        f"{lang}/{fname}: baseline drift {expected} -> {actual}. "
+        "If intentional, run scripts/regen_corpus_baselines.py."
+    )

--- a/tests/scripts/test_readme_runner.py
+++ b/tests/scripts/test_readme_runner.py
@@ -1,0 +1,41 @@
+"""Sanity check that scripts/test_readme.py extracts and runs blocks."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "test_readme.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("test_readme", SCRIPT)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_extract_blocks_finds_bash_fences_and_skips_marked():
+    m = _load()
+    text = (
+        "intro\n"
+        "```bash\necho hi\n```\n"
+        "more\n"
+        "<!-- doctest:skip -->\n"
+        "```bash\necho skipped\n```\n"
+        "```sh\necho sh\n```\n"
+    )
+    blocks = m.extract_blocks(text)
+    bodies = [b for _, b in blocks]
+    assert "echo hi" in bodies
+    assert "echo sh" in bodies
+    assert "echo skipped" not in bodies
+
+
+def test_run_block_executes_in_cwd(tmp_path):
+    m = _load()
+    rc, out, _err = m.run_block("pwd", tmp_path)
+    assert rc == 0
+    assert str(tmp_path.resolve()) in out


### PR DESCRIPTION
## Summary

Foundation release for the deferred Phase 11 work. Ships three independent items per the v4.2.0 scope agreed in the four-PR split:

### 11.2 — Confidence layer
- `Edge.confidence: float` propagated end-to-end (adapters → store → symbol_graph → context)
- Module-level constants `CONF_EXACT/RESOLVED/STITCH/INFERRED/FALLBACK` in `core/adapters/base.py`
- Every `Edge(...)` site in `_generic.py`, `_ts_common.py`, `python_adapter.py` annotated; `stitch.py` and `lockfile.py` already used confidence (no changes).
- `gp context --min-confidence FLOAT` filters low-confidence edges before framing
- CLAUDE.md template **bumped to v2** with verbatim user-mandated paragraph:
  > When confidence < 0.7 on any edge in your context output, verify by reading the source file directly before relying on it. Low-confidence edges are heuristic guesses, not facts.
- **No SQL schema bump needed** — edges are already JSON-serialized columns; `confidence` survives the round-trip without DDL. Old caches read as `confidence=CONF_FALLBACK` until re-ingested.

### 11.5 — Regression corpus (starter)
- 40 original test fixtures (5 per language × 8 languages: python, typescript, javascript, go, rust, java, ruby, csharp)
- `baselines.json` frozen by `scripts/regen_corpus_baselines.py`
- `tests/regression/test_corpus.py` parametrised — 40 cases, exact (symbols, edges) match
- `CONTRIBUTING.md` + `SOURCES.md` document path to the 30/lang target

### 11.9 — README doctest harness
- `scripts/test_readme.py` extracts `bash`/`sh` fences, runs each in fresh tempdir with 30 s timeout, honours `<!-- doctest:skip -->`
- `tests/scripts/test_readme_runner.py` covers extraction + execution
- CI runs as **informational** (`|| true`) until existing illustrative blocks are audited and either skip-marked or made self-contained — flipping to a hard gate is a follow-up.

## Test plan

- [x] 271 tests pass locally (was 223; +6 confidence + 40 corpus + 2 readme runner)
- [x] `ruff check` + `ruff format --check` clean across new scope (added `tests/regression`, `tests/scripts`)
- [x] Determinism: two `gp init --print` runs produce identical jsonl
- [x] `gp doctor` on fresh fixture init: exit 0, no ERROR lines
- [ ] CI green across ubuntu/macOS × py3.10/3.11/3.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)