### PR TITLE
feat(phase-11,12): v4.3.0 — trust score, new probes, drift log, explain, telemetry

### DIFF
--- a/graphify_plus/__main__.py
+++ b/graphify_plus/__main__.py
@@ -294,6 +294,18 @@ def _dispatch(cmd: str, rest: list[str]) -> int:
             return 1
         return 0
 
+    if cmd == "explain":
+        from graphify_plus.interface.cli.explain_cmd import explain_cmd
+
+        try:
+            explain_cmd.main(args=rest, prog_name="graphify-plus explain", standalone_mode=False)
+        except SystemExit as e:
+            return int(e.code or 0)
+        except click.ClickException as e:
+            e.show()
+            return 1
+        return 0
+
     if cmd == "context":
         from graphify_plus.interface.cli.context_cmd import context_cmd
 

--- a/graphify_plus/audit/drift_log.py
+++ b/graphify_plus/audit/drift_log.py
@@ -1,0 +1,100 @@
+"""12.4 — append-only JSONL log of confidence drift events.
+
+When the same edge contributes to N audit failures, its confidence
+should decay. We persist this as a human-readable JSONL file at
+``<repo>/.graphify_plus/confidence_drift.log`` rather than a SQLite
+table — append-only writes, no schema migration, easy to ``cat``.
+
+Public surface
+--------------
+
+``record_drift(repo, edge_key, reason)``  — append one event.
+``aggregate(repo)``                       — replay the log; return
+    ``{edge_key: {"failures": int, "confidence": float}}``.
+``apply_to_graph(G, repo)``               — mutate edge ``confidence``
+    attrs in-place using ``aggregate()`` (floor 0.1).
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+LOG_NAME = "confidence_drift.log"
+DECREMENT = 0.1
+FAILURE_THRESHOLD = 3  # 3+ failures before decrement applies
+FLOOR = 0.1
+
+
+def _log_path(repo: Path) -> Path:
+    return repo / ".graphify_plus" / LOG_NAME
+
+
+def edge_key(src: str, dst: str, kind: str) -> str:
+    return f"{src}|{dst}|{kind}"
+
+
+def record_drift(repo: Path, key: str, reason: str) -> None:
+    p = _log_path(repo)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    entry = {"ts": int(time.time()), "edge": key, "reason": reason}
+    with p.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry, sort_keys=True) + "\n")
+
+
+def aggregate(repo: Path) -> dict[str, dict[str, Any]]:
+    p = _log_path(repo)
+    failures: dict[str, int] = {}
+    if not p.exists():
+        return {}
+    with p.open(encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except ValueError:
+                continue
+            k = entry.get("edge")
+            if isinstance(k, str):
+                failures[k] = failures.get(k, 0) + 1
+    out: dict[str, dict[str, Any]] = {}
+    for k, n in failures.items():
+        if n >= FAILURE_THRESHOLD:
+            decay = ((n - FAILURE_THRESHOLD + 1)) * DECREMENT
+            out[k] = {"failures": n, "decay": decay}
+    return out
+
+
+def apply_to_graph(G, repo: Path) -> int:
+    """Apply aggregated drift to live graph edge attrs. Returns the
+    number of edges adjusted. Floor is ``FLOOR`` (0.1)."""
+    drift = aggregate(repo)
+    if not drift:
+        return 0
+    adjusted = 0
+    for u, v, _k, data in G.edges(keys=True, data=True):
+        kind = data.get("kind") or ""
+        k = edge_key(str(u), str(v), kind)
+        if k in drift:
+            current = float(data.get("confidence", 0.2))
+            new = max(FLOOR, current - drift[k]["decay"])
+            if new != current:
+                data["confidence"] = new
+                adjusted += 1
+    return adjusted
+
+
+__all__ = [
+    "DECREMENT",
+    "FAILURE_THRESHOLD",
+    "FLOOR",
+    "LOG_NAME",
+    "aggregate",
+    "apply_to_graph",
+    "edge_key",
+    "record_drift",
+]

--- a/graphify_plus/audit/probe.py
+++ b/graphify_plus/audit/probe.py
@@ -563,19 +563,151 @@ def probe_centrality_drift(G: nx.Graph, top_k: int = 10) -> dict:
 
 
 # ---------------------------------------------------------------------------
+# Probe 8 (11.7): unresolved imports
+# ---------------------------------------------------------------------------
+
+
+def probe_unresolved_imports(G: nx.Graph) -> dict:
+    """Count `imports` edges flagged ``resolved=False``.
+
+    A high ratio means many imports could not be matched to a definition
+    (heuristic-only edges) — the graph's import surface is brittle.
+    """
+    ok, reason = _validate_graph(G)
+    if not ok:
+        return {"skipped": True, "reason": reason}
+    total = 0
+    unresolved = 0
+    for _u, _v, data in G.edges(data=True):
+        if data.get("kind") != "imports":
+            continue
+        total += 1
+        if not data.get("resolved"):
+            unresolved += 1
+    if total == 0:
+        return {
+            "skipped": False,
+            "total_imports": 0,
+            "unresolved_count": 0,
+            "unresolved_pct": 0.0,
+            "unresolved_imports_grade": "N/A",
+            "interpretation": "no imports edges in graph",
+        }
+    ratio = unresolved / total
+    grade = _grade_from_numeric(1.0 - ratio, thresholds=(0.9, 0.75, 0.5, 0.3))
+    return {
+        "skipped": False,
+        "total_imports": total,
+        "unresolved_count": unresolved,
+        "unresolved_pct": round(ratio * 100, 2),
+        "unresolved_imports_grade": grade,
+        "interpretation": (
+            f"{unresolved} of {total} imports edges are unresolved heuristics."
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Probe 9 (11.7): phantom symbols
+# ---------------------------------------------------------------------------
+
+
+def probe_phantom_symbols(G: nx.Graph) -> dict:
+    """Symbols with degree 0 — defined but never referenced."""
+    ok, reason = _validate_graph(G)
+    if not ok:
+        return {"skipped": True, "reason": reason}
+    total = 0
+    phantoms: list[str] = []
+    for nid, attrs in G.nodes(data=True):
+        if attrs.get("kind") in {None, "external"}:
+            continue
+        total += 1
+        if G.degree(nid) == 0:
+            phantoms.append(_safe_node_label(G, nid))
+    if total == 0:
+        return {
+            "skipped": False,
+            "total_symbols": 0,
+            "phantom_count": 0,
+            "phantom_pct": 0.0,
+            "phantom_grade": "N/A",
+            "interpretation": "no scoreable symbols in graph",
+        }
+    ratio = len(phantoms) / total
+    grade = _grade_from_numeric(1.0 - ratio, thresholds=(0.95, 0.85, 0.7, 0.5))
+    return {
+        "skipped": False,
+        "total_symbols": total,
+        "phantom_count": len(phantoms),
+        "phantom_pct": round(ratio * 100, 2),
+        "phantom_examples": phantoms[:10],
+        "phantom_grade": grade,
+        "interpretation": (
+            f"{len(phantoms)} of {total} symbols have no edges — likely dead or mis-extracted."
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Probe 10 (11.7): low-confidence edge ratio
+# ---------------------------------------------------------------------------
+
+
+def probe_low_confidence_ratio(G: nx.Graph, threshold: float = 0.7) -> dict:
+    """Fraction of edges below the confidence cutoff."""
+    ok, reason = _validate_graph(G)
+    if not ok:
+        return {"skipped": True, "reason": reason}
+    total = 0
+    low = 0
+    for _u, _v, data in G.edges(data=True):
+        c = data.get("confidence")
+        if not isinstance(c, (int, float)):
+            continue
+        total += 1
+        if c < threshold:
+            low += 1
+    if total == 0:
+        return {
+            "skipped": False,
+            "total_edges_with_confidence": 0,
+            "low_confidence_count": 0,
+            "low_confidence_pct": 0.0,
+            "low_confidence_grade": "N/A",
+            "interpretation": "no edges carry confidence values",
+        }
+    ratio = low / total
+    grade = _grade_from_numeric(1.0 - ratio, thresholds=(0.85, 0.7, 0.5, 0.3))
+    return {
+        "skipped": False,
+        "total_edges_with_confidence": total,
+        "low_confidence_count": low,
+        "low_confidence_pct": round(ratio * 100, 2),
+        "low_confidence_grade": grade,
+        "interpretation": (
+            f"{low} of {total} edges have confidence < {threshold}."
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
 # Audit aggregation
 # ---------------------------------------------------------------------------
 
 
 def _aggregate_grade(probe_results: dict[str, dict]) -> dict:
     grade_keys = [
-        ("edge_deletion_stability", "stability_grade", 0.20),
-        ("confidence_drift", "drift_grade", 0.15),
-        ("rename_sensitivity", "rename_grade", 0.10),
-        ("structural_fragility", "structural_grade", 0.20),
-        ("lonely_inferred_edges", "lonely_grade", 0.15),
-        ("modularity_quality", "modularity_grade", 0.10),
-        ("centrality_drift", "centrality_grade", 0.10),
+        ("edge_deletion_stability", "stability_grade", 0.15),
+        ("confidence_drift", "drift_grade", 0.10),
+        ("rename_sensitivity", "rename_grade", 0.08),
+        ("structural_fragility", "structural_grade", 0.15),
+        ("lonely_inferred_edges", "lonely_grade", 0.10),
+        ("modularity_quality", "modularity_grade", 0.07),
+        ("centrality_drift", "centrality_grade", 0.05),
+        ("unresolved_imports", "unresolved_imports_grade", 0.10),
+        ("phantom_symbols", "phantom_grade", 0.10),
+        ("low_confidence_ratio", "low_confidence_grade", 0.10),
     ]
 
     weighted_sum = 0.0
@@ -648,6 +780,9 @@ def run_audit(
         "lonely_inferred_edges": lambda: probe_lonely_inferred_edges(G),
         "modularity_quality": lambda: probe_modularity_quality(G),
         "centrality_drift": lambda: probe_centrality_drift(G),
+        "unresolved_imports": lambda: probe_unresolved_imports(G),
+        "phantom_symbols": lambda: probe_phantom_symbols(G),
+        "low_confidence_ratio": lambda: probe_low_confidence_ratio(G),
     }
 
     if only:
@@ -667,14 +802,20 @@ def run_audit(
 
     aggregate = _aggregate_grade(results)
 
+    weighted = aggregate["weighted_score"]
+    # weighted_score is on a 0..4 (F..A) scale — normalise to 0..100.
+    trust_score = (
+        int(round(float(weighted) / 4.0 * 100)) if isinstance(weighted, (int, float)) else None
+    )
     return {
-        "_schema": "graphify-plus-audit-1.1",
+        "_schema": "graphify-plus-audit-1.2",
         "graph_size": {
             "nodes": G.number_of_nodes(),
             "edges": G.number_of_edges(),
             "directed": G.is_directed(),
             "multigraph": G.is_multigraph(),
         },
+        "trust_score": trust_score,
         "overall_grade": aggregate["overall_grade"],
         "weighted_score": aggregate["weighted_score"],
         "component_grades": aggregate["components"],
@@ -693,6 +834,10 @@ def format_audit_report(audit: dict) -> str:
         return f"# Audit\n\nSkipped: {audit.get('reason', 'unknown')}\n"
 
     lines = ["# Adversarial Audit Report\n"]
+    trust = audit.get("trust_score")
+    if isinstance(trust, int):
+        warn = " — verify findings before relying on the graph" if trust < 70 else ""
+        lines.append(f"## Trust score: **{trust} / 100**{warn}\n")
     s = audit.get("graph_size", {})
     direction = "directed" if s.get("directed") else "undirected"
     lines.append(
@@ -718,6 +863,9 @@ def format_audit_report(audit: dict) -> str:
         ("lonely_inferred_edges", "5. Lonely INFERRED edges", "lonely_grade"),
         ("modularity_quality", "6. Modularity quality", "modularity_grade"),
         ("centrality_drift", "7. Centrality drift", "centrality_grade"),
+        ("unresolved_imports", "8. Unresolved imports", "unresolved_imports_grade"),
+        ("phantom_symbols", "9. Phantom symbols", "phantom_grade"),
+        ("low_confidence_ratio", "10. Low-confidence edges", "low_confidence_grade"),
     ]
 
     for key, title, grade_field in sections:

--- a/graphify_plus/interface/cli/explain_cmd.py
+++ b/graphify_plus/interface/cli/explain_cmd.py
@@ -1,0 +1,87 @@
+"""``gp explain <symbol>`` — render a one-screen brief on a single symbol.
+
+Shows the skeleton, 1-hop neighbours (with confidence), and counts of
+inbound/outbound edges. Read-only.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+from ...core.symbol_graph import build as build_graph
+from ...runtime.store import Store, cache_path
+
+
+@click.command("explain")
+@click.option(
+    "--repo",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    default=Path("."),
+)
+@click.argument("symbol", type=str)
+def explain_cmd(repo: Path, symbol: str) -> None:
+    """Print a brief on ``symbol`` (qualified name or id)."""
+    repo = repo.resolve()
+    if not cache_path(repo).exists():
+        raise click.ClickException(
+            f"No cache at {cache_path(repo)}. Run 'graphify-plus init --repo {repo}' first."
+        )
+    store = Store(cache_path(repo))
+    try:
+        if store.get_symbol(symbol) is not None:
+            sid = symbol
+        else:
+            matches = store.find_symbols_by_qualified_name(symbol)
+            if not matches:
+                raise click.ClickException(f"No symbol matches: {symbol}")
+            if len(matches) > 1:
+                names = ", ".join(s["qualified_name"] for s in matches[:5])
+                raise click.ClickException(f"Ambiguous {symbol!r}: {names}")
+            sid = matches[0]["id"]
+        sym = store.get_symbol(sid)
+        if sym is None:
+            raise click.ClickException(f"Symbol vanished: {sid}")
+        symbols = store.all_symbols()
+        edges = store.all_edges()
+        G = build_graph(symbols, edges)
+        skeleton = store.get_skeleton_for_symbol(sid)
+
+        click.echo(f"# {sym.get('qualified_name')} ({sym.get('kind')})")
+        click.echo(f"path: {sym.get('path')}  span: {sym.get('span')}")
+        click.echo(f"language: {sym.get('language')}")
+        if sym.get("docstring"):
+            click.echo(f"\n{sym['docstring']}")
+        if skeleton:
+            click.echo("\n## Skeleton\n")
+            click.echo(skeleton)
+
+        click.echo("\n## Outbound edges")
+        any_out = False
+        for u, v, _k, data in G.out_edges(sid, keys=True, data=True):
+            del u
+            conf = data.get("confidence", "?")
+            label = G.nodes[v].get("qualified_name") or v
+            mark = "  [low]" if isinstance(conf, (int, float)) and conf < 0.7 else ""
+            click.echo(f"  -[{data.get('kind')}]-> {label}  conf={conf}{mark}")
+            any_out = True
+        if not any_out:
+            click.echo("  (none)")
+
+        click.echo("\n## Inbound edges")
+        any_in = False
+        for u, v, _k, data in G.in_edges(sid, keys=True, data=True):
+            del v
+            conf = data.get("confidence", "?")
+            label = G.nodes[u].get("qualified_name") or u
+            mark = "  [low]" if isinstance(conf, (int, float)) and conf < 0.7 else ""
+            click.echo(f"  {label} -[{data.get('kind')}]->  conf={conf}{mark}")
+            any_in = True
+        if not any_in:
+            click.echo("  (none)")
+    finally:
+        store.close()
+
+
+__all__ = ["explain_cmd"]

--- a/graphify_plus/interface/telemetry.py
+++ b/graphify_plus/interface/telemetry.py
@@ -1,0 +1,67 @@
+"""11.8 — opt-in telemetry.
+
+Disabled by default. Activates only when ``GRAPHIFY_TELEMETRY_URL`` is
+set in the environment. Sends a minimal envelope: command name,
+duration_ms, file_count_bucket, error_code (if any), version, OS,
+Python version. Never sends paths, source, symbol names, or repo
+identity.
+
+This module never raises into the caller — telemetry must not block or
+crash the CLI. All exceptions are swallowed; a one-line debug message
+goes to ``stderr`` only when ``GP_DEBUG=1`` is set.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import sys
+import urllib.error
+import urllib.request
+
+from .. import __version__ as _GP_VERSION
+
+_BUCKETS = (10, 100, 1_000, 10_000, 100_000)
+
+
+def _bucket(n: int) -> str:
+    for b in _BUCKETS:
+        if n <= b:
+            return f"<={b}"
+    return f">{_BUCKETS[-1]}"
+
+
+def is_enabled() -> bool:
+    return bool(os.environ.get("GRAPHIFY_TELEMETRY_URL"))
+
+
+def emit(
+    command: str,
+    duration_ms: int,
+    file_count: int = 0,
+    error_code: str | None = None,
+) -> None:
+    if not is_enabled():
+        return
+    url = os.environ["GRAPHIFY_TELEMETRY_URL"]
+    payload = {
+        "command": command,
+        "duration_ms": duration_ms,
+        "file_count_bucket": _bucket(file_count),
+        "error_code": error_code,
+        "version": _GP_VERSION,
+        "os": platform.system().lower(),
+        "python": f"{sys.version_info.major}.{sys.version_info.minor}",
+    }
+    try:
+        import json
+
+        data = json.dumps(payload, sort_keys=True).encode("utf-8")
+        req = urllib.request.Request(url, data=data, headers={"Content-Type": "application/json"})
+        urllib.request.urlopen(req, timeout=2.0).close()  # noqa: S310
+    except (urllib.error.URLError, OSError, ValueError) as exc:
+        if os.environ.get("GP_DEBUG") == "1":
+            print(f"telemetry: dropped ({exc})", file=sys.stderr)
+
+
+__all__ = ["emit", "is_enabled"]

--- a/scripts/test_readme.py
+++ b/scripts/test_readme.py
@@ -1,3 +1,4 @@
+# TODO: flip to hard gate once illustrative-only blocks are tagged with doctest:skip
 """11.9 — README doc verification.
 
 Walks ``README.md`` (and any other docs added in future), extracts every

--- a/tests/audit/test_drift_log.py
+++ b/tests/audit/test_drift_log.py
@@ -1,0 +1,46 @@
+"""12.4 — confidence drift JSONL log."""
+
+from __future__ import annotations
+
+import networkx as nx
+
+from graphify_plus.audit.drift_log import (
+    FAILURE_THRESHOLD,
+    FLOOR,
+    aggregate,
+    apply_to_graph,
+    edge_key,
+    record_drift,
+)
+
+
+def test_record_and_aggregate_below_threshold(tmp_path):
+    (tmp_path / ".graphify_plus").mkdir()
+    k = edge_key("a", "b", "imports")
+    for _ in range(FAILURE_THRESHOLD - 1):
+        record_drift(tmp_path, k, "stale-edge")
+    assert aggregate(tmp_path) == {}
+
+
+def test_aggregate_decays_above_threshold(tmp_path):
+    k = edge_key("a", "b", "imports")
+    for _ in range(FAILURE_THRESHOLD + 1):
+        record_drift(tmp_path, k, "stale-edge")
+    out = aggregate(tmp_path)
+    assert k in out
+    assert out[k]["failures"] == FAILURE_THRESHOLD + 1
+    assert out[k]["decay"] > 0
+
+
+def test_apply_to_graph_floors_at_floor(tmp_path):
+    g = nx.MultiDiGraph()
+    g.add_node("a")
+    g.add_node("b")
+    g.add_edge("a", "b", kind="imports", confidence=0.2)
+    k = edge_key("a", "b", "imports")
+    for _ in range(20):
+        record_drift(tmp_path, k, "stale-edge")
+    n = apply_to_graph(g, tmp_path)
+    assert n == 1
+    _u, _v, _k, data = next(iter(g.edges(keys=True, data=True)))
+    assert data["confidence"] == FLOOR

--- a/tests/audit/test_trust_score_and_new_probes.py
+++ b/tests/audit/test_trust_score_and_new_probes.py
@@ -1,0 +1,68 @@
+"""11.7 — trust score banner + new probes."""
+
+from __future__ import annotations
+
+import networkx as nx
+
+from graphify_plus.audit.probe import (
+    format_audit_report,
+    probe_low_confidence_ratio,
+    probe_phantom_symbols,
+    probe_unresolved_imports,
+    run_audit,
+)
+
+
+def _toy_graph() -> nx.MultiDiGraph:
+    g = nx.MultiDiGraph()
+    g.add_node("m", kind="module", qualified_name="m", language="python", path="m.py", name="m")
+    g.add_node("f", kind="function", qualified_name="m.f", language="python", path="m.py", name="f")
+    g.add_node(
+        "g_orphan",
+        kind="function",
+        qualified_name="m.orphan",
+        language="python",
+        path="m.py",
+        name="orphan",
+    )
+    g.add_edge("m", "f", kind="contains", resolved=True, confidence=1.0)
+    g.add_edge("m", "ext", kind="imports", resolved=False, confidence=0.2)
+    return g
+
+
+def test_unresolved_imports_probe():
+    g = _toy_graph()
+    res = probe_unresolved_imports(g)
+    assert res["total_imports"] == 1
+    assert res["unresolved_count"] == 1
+    assert res["unresolved_imports_grade"] in {"A", "B", "C", "D", "F"}
+
+
+def test_phantom_symbols_probe_finds_orphans():
+    g = _toy_graph()
+    res = probe_phantom_symbols(g)
+    assert res["phantom_count"] >= 1
+
+
+def test_low_confidence_ratio_probe():
+    g = _toy_graph()
+    res = probe_low_confidence_ratio(g, threshold=0.7)
+    assert res["total_edges_with_confidence"] == 2
+    assert res["low_confidence_count"] == 1
+
+
+def test_run_audit_includes_trust_score_in_0_100_range():
+    g = _toy_graph()
+    audit = run_audit(g, iterations=2)
+    assert "trust_score" in audit
+    ts = audit["trust_score"]
+    assert isinstance(ts, int)
+    assert 0 <= ts <= 100
+
+
+def test_format_audit_report_renders_trust_banner():
+    g = _toy_graph()
+    audit = run_audit(g, iterations=2)
+    report = format_audit_report(audit)
+    assert "Trust score" in report
+    assert "/ 100" in report

--- a/tests/interface/test_explain_cmd.py
+++ b/tests/interface/test_explain_cmd.py
@@ -1,0 +1,27 @@
+"""11.10 — gp explain command."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_explain_renders_neighbours(tmp_path: Path):
+    repo = tmp_path / "sample"
+    repo.mkdir()
+    (repo / "a.py").write_text("def f():\n    return 1\n")
+    subprocess.run(
+        [sys.executable, "-m", "graphify_plus", "init", "--repo", str(repo), "--no-parallel"],
+        check=True,
+        capture_output=True,
+    )
+    out = subprocess.run(
+        [sys.executable, "-m", "graphify_plus", "explain", "--repo", str(repo), "f"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert "function" in out.stdout
+    assert "Outbound edges" in out.stdout
+    assert "Inbound edges" in out.stdout

--- a/tests/interface/test_telemetry.py
+++ b/tests/interface/test_telemetry.py
@@ -1,0 +1,25 @@
+"""11.8 — telemetry is opt-in and never raises."""
+
+from __future__ import annotations
+
+from graphify_plus.interface import telemetry
+
+
+def test_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("GRAPHIFY_TELEMETRY_URL", raising=False)
+    assert not telemetry.is_enabled()
+    # Calling emit with no env should be a no-op.
+    telemetry.emit("init", duration_ms=10, file_count=5)
+
+
+def test_emit_swallows_errors(monkeypatch):
+    monkeypatch.setenv("GRAPHIFY_TELEMETRY_URL", "http://127.0.0.1:1/never-listens")
+    monkeypatch.setenv("GP_DEBUG", "0")
+    # Should not raise even though the endpoint won't connect.
+    telemetry.emit("init", duration_ms=10, file_count=5)
+
+
+def test_bucket_thresholds():
+    assert telemetry._bucket(0) == "<=10"
+    assert telemetry._bucket(50) == "<=100"
+    assert telemetry._bucket(500_000) == ">100000"


### PR DESCRIPTION
## Summary

v4.3.0 ships the must-haves from the agreed scope (11.7 + 11.8 + 11.10 + 12.4) and explicitly defers the heavier follow-ups.

### 11.7 — Adversarial audit expansion + trust score
- **Trust score (0–100)** banner — primary user-facing output, rendered at the top of every audit. Sub-70 prints a "verify findings" warning per spec.
- Three new probes wired into `run_audit()` aggregation and `format_audit_report()`:
  - `probe_unresolved_imports`
  - `probe_phantom_symbols`
  - `probe_low_confidence_ratio`
- **Deferred to follow-up:** `stale-edge` and `skeleton-source-divergence` probes (need filesystem/source diffing — separate concern).

### 12.4 — Confidence drift feedback loop (JSONL)
- Per your guidance, used append-only JSONL at `.graphify_plus/confidence_drift.log` rather than a new SQLite table. Same forward-compat reasoning as 11.2.
- `record_drift / aggregate / apply_to_graph` with FAILURE_THRESHOLD=3, DECREMENT=0.1, FLOOR=0.1.

### 11.8 — Opt-in telemetry stub
- Disabled unless `GRAPHIFY_TELEMETRY_URL` set. Minimal envelope only (command, duration, bucket, error code, version, OS, python). Errors swallowed; never blocks CLI.
- **Deferred:** interactive `gp report-error` redacted-traceback flow.

### 11.10 — `gp explain`
- One-screen symbol brief: skeleton + 1-hop in/out edges with confidence, low-conf marker. Wired into `__main__.py`.
- **Deferred:** first-run wizard (independent; can land any time).

### Housekeeping
- TODO at top of `scripts/test_readme.py` to flip the doctest gate to enforcing once illustrative blocks are skip-tagged.
- Tracking issue [#15](https://github.com/ahmadzubair9655/graphify-plus/issues/15) opened for stitch/lockfile confidence-constants alignment.

## Test plan

- [x] 283 tests pass locally (was 271; +12 across audit, drift_log, telemetry, explain)
- [x] ruff check + format clean across in-scope tree
- [x] Determinism: jsonl byte-identical across two `gp init --print` runs
- [x] `gp doctor` on fresh fixture: exit 0, no ERROR
- [ ] CI green across ubuntu/macOS × py3.10/3.11/3.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)