### PR TITLE
fix(store): dedupe symbols by id in replace_all

### DIFF
--- a/graphify_plus/runtime/store.py
+++ b/graphify_plus/runtime/store.py
@@ -21,6 +21,7 @@ Phase 11 hardens this layer:
 
 from __future__ import annotations
 
+import logging
 import shutil
 import sqlite3
 import time
@@ -30,6 +31,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import orjson
+
+log = logging.getLogger("graphify_plus.runtime.store")
 
 from ..core.adapters import Edge, Symbol
 from ..interface.errors import (
@@ -217,12 +220,38 @@ class Store:
 
     # ---- symbols & edges ------------------------------------------------
     def replace_all(self, symbols: Iterable[Symbol], edges: Iterable[Edge]) -> None:
+        # Dedupe symbols by id (last occurrence wins) so callers feeding
+        # multi-pass extractor output don't blow up on the UNIQUE(id)
+        # constraint. Duplicate IDs typically signal an upstream extractor
+        # bug (TS overload, default-export collision, two adapters claiming
+        # the same file) — log a warning with a sample so it stays
+        # discoverable in debug.log instead of silently being collapsed.
+        unique_symbols: dict[str, Symbol] = {}
+        dup_count = 0
+        dup_samples: list[str] = []
+        for s in symbols:
+            sid = s["id"]
+            if sid in unique_symbols:
+                dup_count += 1
+                if len(dup_samples) < 5:
+                    dup_samples.append(sid)
+            unique_symbols[sid] = s
+        if dup_count:
+            log.warning(
+                "replace_all: dropped %d duplicate symbol id(s); samples=%s",
+                dup_count,
+                dup_samples,
+            )
+
         with self.tx():
             self.conn.execute("DELETE FROM symbols")
             self.conn.execute("DELETE FROM edges")
             self.conn.executemany(
                 "INSERT INTO symbols(id, json) VALUES (?, ?)",
-                [(s["id"], orjson.dumps(s, option=orjson.OPT_SORT_KEYS)) for s in symbols],
+                [
+                    (sid, orjson.dumps(s, option=orjson.OPT_SORT_KEYS))
+                    for sid, s in unique_symbols.items()
+                ],
             )
             self.conn.executemany(
                 "INSERT INTO edges(src, dst, kind, json) VALUES (?, ?, ?, ?)",

--- a/tests/runtime/test_store.py
+++ b/tests/runtime/test_store.py
@@ -31,6 +31,25 @@ def test_store_meta(tmp_path: Path):
         s.close()
 
 
+def test_replace_all_dedupes_duplicate_symbol_ids(tmp_path: Path, caplog):
+    syms = [
+        {"id": "dup", "kind": "function", "name": "foo", "path": "a.ts", "span": (1, 1)},
+        {"id": "unique", "kind": "function", "name": "bar", "path": "a.ts", "span": (2, 2)},
+        {"id": "dup", "kind": "function", "name": "foo_v2", "path": "a.ts", "span": (3, 3)},
+    ]
+    s = Store(cache_path(tmp_path))
+    try:
+        with caplog.at_level("WARNING", logger="graphify_plus.runtime.store"):
+            s.replace_all(syms, [])  # type: ignore[arg-type]
+        ids = {x["id"] for x in s.all_symbols()}
+        assert ids == {"dup", "unique"}
+        # last-write-wins
+        assert s.get_symbol("dup")["name"] == "foo_v2"  # type: ignore[index]
+        assert any("duplicate symbol id" in r.message for r in caplog.records)
+    finally:
+        s.close()
+
+
 def test_skeleton_table(tmp_path: Path):
     s = Store(cache_path(tmp_path))
     try:


### PR DESCRIPTION
## Summary
- `replace_all` was inserting symbols straight into the `UNIQUE(id)`-constrained `symbols` table without dedup, crashing `gp init` with `GP-INTERNAL-ERROR` whenever an extractor emitted two symbols with the same id (TS overload, default-export collision, multi-adapter overlap).
- Now dedupe by id with last-write-wins (matches the function's "replace" contract) and log a WARNING with the dropped count and up to 5 sample ids so the upstream extractor bug stays discoverable in `.graphify_plus/debug.log`.
- Adds `test_replace_all_dedupes_duplicate_symbol_ids` covering both the dedupe and the warning.

## Verification
Reproduced on a 450-file Next.js + Sanity repo that previously aborted init. With the fix, init completes:

\`\`\`
gp init: parsed 450 files, 1504 symbols, 2704 edges (skipped 0)
replace_all: dropped 1 duplicate symbol id(s); samples=['e92934d0fcd91dd7']
\`\`\`

The single flagged duplicate is tracked separately for upstream extractor investigation — see follow-up issue.

## Test plan
- [x] `pytest tests/runtime/test_store.py` passes
- [x] Live `gp init` against the previously-failing repo succeeds
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)