### PR TITLE
fix(audit,claude-md): read graph_symbols.jsonl, use `gp` alias (v5.0.2)

### DIFF
--- a/graphify_plus/audit/cli.py
+++ b/graphify_plus/audit/cli.py
@@ -45,6 +45,15 @@ _PROBE_FUNCS = {
 
 
 def _load_graph(path: Path) -> nx.Graph:
+    # Two on-disk formats coexist:
+    #   * legacy single-blob ``graph.json`` with {"nodes": [...], "edges": [...]}
+    #   * v5+ ``graph_symbols.jsonl`` produced by ``gp init`` — first line is
+    #     a {"_meta": {...}} header, subsequent lines are
+    #     {"kind": "symbol"|"edge", ...fields}. Symbol id lives at "id";
+    #     edge endpoints live at "src"/"dst" (not "source"/"target").
+    # Detect by extension; .jsonl wins, everything else is treated as legacy.
+    if path.suffix == ".jsonl":
+        return _load_graph_jsonl(path)
     with open(path) as f:
         data = json.load(f)
     G = nx.Graph()
@@ -55,6 +64,32 @@ def _load_graph(path: Path) -> nx.Graph:
     for e in data.get("edges", data.get("links", [])):
         attrs = {k: v for k, v in e.items() if k not in ("source", "target")}
         G.add_edge(e.get("source"), e.get("target"), **attrs)
+    return G
+
+
+def _load_graph_jsonl(path: Path) -> nx.Graph:
+    # Note on the init writer: it emits records as ``{"kind": "symbol", **s}``
+    # / ``{"kind": "edge", **e}``, but the spread overrides the leading
+    # marker because Symbol/Edge dicts carry their own "kind" field
+    # (module/function/calls/contains/...). So we must discriminate by
+    # field presence — header has "_meta", edges have src+dst, symbols
+    # have id.
+    G = nx.Graph()
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            rec = json.loads(line)
+            if "_meta" in rec:
+                continue
+            if "src" in rec and "dst" in rec:
+                attrs = {k: v for k, v in rec.items() if k not in ("src", "dst")}
+                G.add_edge(rec["src"], rec["dst"], **attrs)
+            elif "id" in rec:
+                node_id = rec["id"]
+                attrs = {k: v for k, v in rec.items() if k != "id"}
+                G.add_node(node_id, **attrs)
     return G
 
 

--- a/graphify_plus/interface/cli/claude_md_cmd.py
+++ b/graphify_plus/interface/cli/claude_md_cmd.py
@@ -30,7 +30,7 @@ from ...runtime.store import Store, cache_path
 
 START_MARKER = "<!-- graphify-plus:start -->"
 END_MARKER = "<!-- graphify-plus:end -->"
-TEMPLATE_VERSION = 2
+TEMPLATE_VERSION = 3
 
 
 def _detect_stack(symbols) -> list[str]:
@@ -47,7 +47,7 @@ def _detect_stack(symbols) -> list[str]:
 def render_section(repo: Path) -> str:
     if not cache_path(repo).exists():
         raise click.ClickException(
-            f"No cache at {cache_path(repo)}. Run 'graphify-plus init --repo {repo}' first."
+            f"No cache at {cache_path(repo)}. Run 'gp init --repo {repo}' first."
         )
     store = Store(cache_path(repo))
     try:
@@ -75,22 +75,26 @@ def render_section(repo: Path) -> str:
         for s in stack:
             lines.append(f"- {s}")
     else:
-        lines.append("- _(empty — run `graphify-plus init --repo .` to populate)_")
+        lines.append("- _(empty — run `gp init --repo .` to populate)_")
     lines.append("")
 
     lines.extend(
         [
             "### Workflow",
             "",
-            '1. **Plan** — `graphify-plus plan --task "<description>"` writes '
+            '1. **Plan** — `gp plan --task "<description>"` writes '
             "`STAGING_PLAN.md` with the impacted symbols in topological order.",
-            "2. **Context** — `graphify-plus context --target <symbol>` returns a "
+            "2. **Context** — `gp context --target <symbol>` returns a "
             "token-budgeted slice of the symbol graph for the AI to read.",
             "3. **Guardrails** — pipe a proposed-edit JSON into "
-            "`graphify-plus guardrails` before applying changes; non-zero exit means "
+            "`gp guardrails` before applying changes; non-zero exit means "
             "a rule (`.graphify_plus/rules.yaml`) blocks the edit.",
-            "4. **Audit** — `graphify-plus audit <graph.json>` runs the structural "
-            "audit; `graphify-plus drift check` re-evaluates the live rule set.",
+            "4. **Audit** — `gp audit .graphify_plus/graph_symbols.jsonl` runs the structural "
+            "audit; `gp drift check` re-evaluates the live rule set.",
+            "",
+            "Optional enrichments (run after `gp init`): `gp enrich git` adds "
+            "volatility/age, `gp enrich lockfile` resolves third-party deps, "
+            "`gp enrich telemetry <spans.jsonl>` overlays runtime data.",
             "",
             "### MCP server",
             "",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graphify-plus"
-version = "5.0.1"
+version = "5.0.2"
 description = "Universal context & execution engine for AI coding agents — Tree-sitter frontend, symbol graph, skeleton CAS, MCP server."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/audit/test_cli_jsonl.py
+++ b/tests/audit/test_cli_jsonl.py
@@ -1,0 +1,43 @@
+"""`gp audit` reads both legacy graph.json and v5+ graph_symbols.jsonl."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from graphify_plus.audit.cli import _load_graph
+
+
+def test_load_graph_reads_jsonl(tmp_path: Path):
+    p = tmp_path / "graph_symbols.jsonl"
+    # Mirror what `gp init` actually writes: dict spread overrides the
+    # leading "kind" marker, so symbols carry their own kind (module,
+    # function, ...) and edges carry their relation kind (calls, etc.).
+    lines = [
+        {"_meta": {"kind": "header", "version": 1, "symbols": 2, "edges": 1}},
+        {"id": "a", "kind": "function", "name": "A", "language": "python"},
+        {"id": "b", "kind": "function", "name": "B", "language": "python"},
+        {"src": "a", "dst": "b", "kind": "calls", "confidence": 0.9},
+    ]
+    p.write_text("\n".join(json.dumps(rec) for rec in lines) + "\n")
+
+    G = _load_graph(p)
+    assert set(G.nodes) == {"a", "b"}
+    assert G.has_edge("a", "b")
+    assert G.nodes["a"]["name"] == "A"
+    assert G.nodes["a"]["language"] == "python"
+
+
+def test_load_graph_still_reads_legacy_json(tmp_path: Path):
+    p = tmp_path / "graph.json"
+    p.write_text(
+        json.dumps(
+            {
+                "nodes": [{"id": "a", "name": "A"}, {"id": "b", "name": "B"}],
+                "edges": [{"source": "a", "target": "b"}],
+            }
+        )
+    )
+    G = _load_graph(p)
+    assert set(G.nodes) == {"a", "b"}
+    assert G.has_edge("a", "b")

--- a/tests/interface/test_claude_md_template_v3.py
+++ b/tests/interface/test_claude_md_template_v3.py
@@ -1,4 +1,4 @@
-"""Template v2 emits the verbatim confidence-warning paragraph."""
+"""Template v3 emits the verbatim confidence-warning paragraph and uses `gp` aliases."""
 
 from __future__ import annotations
 
@@ -13,7 +13,7 @@ CONFIDENCE_PARAGRAPH = (
 )
 
 
-def test_template_version_marker_is_2_and_warning_present(tmp_path: Path):
+def test_template_version_marker_is_3_and_uses_gp_alias(tmp_path: Path):
     repo = tmp_path / "sample"
     repo.mkdir()
     (repo / "a.py").write_text("def f(): pass\n")
@@ -28,5 +28,14 @@ def test_template_version_marker_is_2_and_warning_present(tmp_path: Path):
         capture_output=True,
     )
     text = (repo / "CLAUDE.md").read_text()
-    assert "<!-- graphify-plus-template-version: 2 -->" in text
+    assert "<!-- graphify-plus-template-version: 3 -->" in text
     assert CONFIDENCE_PARAGRAPH in text
+    # v3: workflow steps use the `gp` alias and audit points at the JSONL artefact.
+    assert "`gp plan " in text
+    assert "`gp context " in text
+    assert "`gp audit .graphify_plus/graph_symbols.jsonl`" in text
+    assert "gp enrich git" in text
+    # `graphify-plus <subcommand>` should no longer appear in the workflow section.
+    assert "graphify-plus init" not in text
+    assert "graphify-plus plan" not in text
+    assert "graphify-plus audit" not in text


### PR DESCRIPTION
## Summary

Three bugs found by Opus running graphify-plus on the smart-energie codebase. Bug #4 (extractor duplicate id) is tracked separately as #26.

### Bug 1 — \`gp audit\` cannot read \`graph_symbols.jsonl\` (critical)
\`audit.cli._load_graph\` was hard-coded to \`json.load\` the legacy single-blob \`graph.json\` format and died with \`JSONDecodeError: Extra data\` against the JSONL produced by \`gp init\`. Audit was unusable on any post-v5 workspace.

Fix: autodetect by extension. New \`_load_graph_jsonl\` discriminates by field presence — header has \`_meta\`, edges have \`src\`+\`dst\`, symbols have \`id\`. The \`kind\` marker the init writer prepends is overridden by the symbol/edge's own \`kind\` field via dict spread, so we can't rely on it.

### Bug 2 + 3 — CLAUDE.md template uses \`graphify-plus\` instead of \`gp\`, omits enrich
Template bumped to **v3**:
- Workflow commands now use the \`gp\` alias (matches the console-script registered in #24).
- Audit step now points at the JSONL artefact (\`gp audit .graphify_plus/graph_symbols.jsonl\`).
- New line documents \`gp enrich {git,lockfile,telemetry}\` with correct (subcommand, not flag) syntax.

### Version
Bumps to **5.0.2**.

## Verification
\`\`\`
$ gp audit /Users/mac/Downloads/SMART-ENERGIE-WEBSITE-CLEAN/smart-energie/.graphify_plus/graph_symbols.jsonl
# Audit
... 10 probes ran across 1503 symbols / 2698 edges ...
\`\`\`

## Test plan
- [x] New \`tests/audit/test_cli_jsonl.py\` covers JSONL + legacy paths
- [x] \`tests/interface/test_claude_md_template_v3.py\` asserts \`gp\` alias + JSONL audit path + \`gp enrich git\`
- [x] Local: 224 tests pass (excluded modules require dev extras not installed locally — CI installs \`[dev]\`)
- [ ] CI green
- [x] End-to-end \`gp audit\` on smart-energie JSONL

🤖 Generated with [Claude Code](https://claude.com/claude-code)