### PR TITLE
fix(resolve_aliases): JSONC stripper must be string-aware (v5.0.4)

### DIFF
--- a/graphify_plus/core/resolve_aliases.py
+++ b/graphify_plus/core/resolve_aliases.py
@@ -38,17 +38,58 @@ from pathlib import Path
 from .adapters.base import CONF_RESOLVED, Edge, Symbol
 
 # ---------- comment-stripping JSON loader ----------------------------------
+#
+# A naive ``/\*.*?\*/`` regex eats glob patterns like ``"**/*.ts"`` inside
+# JSON string literals (the leading ``/*`` looks like the start of a block
+# comment, the closing ``*/`` matches the next ``*/`` even when it is the
+# end of an unrelated glob). We scan char-by-char and strip comments only
+# OUTSIDE of string literals — essential for tsconfig files that include
+# glob arrays.
 
-_LINE_COMMENT = re.compile(r"//[^\n]*")
-_BLOCK_COMMENT = re.compile(r"/\*.*?\*/", re.DOTALL)
 _TRAILING_COMMA = re.compile(r",(\s*[}\]])")
 
 
 def _strip_jsonc(text: str) -> str:
-    text = _BLOCK_COMMENT.sub("", text)
-    text = _LINE_COMMENT.sub("", text)
-    text = _TRAILING_COMMA.sub(r"\1", text)
-    return text
+    """Remove ``//`` line comments, ``/* */`` block comments, and trailing
+    commas — but only outside JSON string literals.
+    """
+    out: list[str] = []
+    i = 0
+    n = len(text)
+    in_string = False
+    while i < n:
+        ch = text[i]
+        if in_string:
+            out.append(ch)
+            if ch == "\\" and i + 1 < n:
+                out.append(text[i + 1])
+                i += 2
+                continue
+            if ch == '"':
+                in_string = False
+            i += 1
+            continue
+        if ch == '"':
+            in_string = True
+            out.append(ch)
+            i += 1
+            continue
+        # Outside a string — strip comments.
+        if ch == "/" and i + 1 < n:
+            nxt = text[i + 1]
+            if nxt == "/":
+                # line comment: skip to next newline
+                j = text.find("\n", i + 2)
+                i = n if j == -1 else j
+                continue
+            if nxt == "*":
+                # block comment: skip to closing */
+                j = text.find("*/", i + 2)
+                i = n if j == -1 else j + 2
+                continue
+        out.append(ch)
+        i += 1
+    return _TRAILING_COMMA.sub(r"\1", "".join(out))
 
 
 def _load_jsonc(path: Path) -> dict | None:

--- a/graphify_plus/interface/cli/doctor_cmd.py
+++ b/graphify_plus/interface/cli/doctor_cmd.py
@@ -138,6 +138,53 @@ def _check_skipped(repo: Path) -> list[Diagnostic]:
     return out
 
 
+def _check_audit_capability(repo: Path) -> list[Diagnostic]:
+    """Surface audit-probe capability gaps before the operator runs `gp audit`.
+
+    Three probes (edge_deletion_stability, modularity_quality,
+    confidence_drift) require enrichment data that ``gp init`` alone
+    does not produce — Louvain communities and INFERRED-confidence
+    edges. If those signals are absent, the probes will SKIP. Tell the
+    operator NOW so they don't first run an audit, see SKIPs, and have
+    to backtrack.
+    """
+    db = cache_path(repo)
+    if not db.exists():
+        return []
+    try:
+        store = Store(db, integrity_check=False)
+    except Exception:  # noqa: BLE001
+        return []
+    try:
+        symbols = store.all_symbols()
+        edges = store.all_edges()
+    finally:
+        store.close()
+    needs_community = not any("community" in s for s in symbols)
+    needs_inferred = sum(1 for e in edges if e.get("confidence_score") is not None) < 3
+    out: list[Diagnostic] = []
+    if needs_community or needs_inferred:
+        gaps: list[str] = []
+        if needs_community:
+            gaps.append("edge_deletion_stability + modularity_quality (need community)")
+        if needs_inferred:
+            gaps.append("confidence_drift (needs ≥3 INFERRED-confidence edges)")
+        out.append(
+            Diagnostic(
+                "Audit capability",
+                WARN,
+                f"{len(gaps)} audit probe set(s) will SKIP without enrichment",
+                remediation=(
+                    "Run 'gp enrich --community' and/or feed telemetry "
+                    "before 'gp audit' to lift the trust score:\n      " + "; ".join(gaps)
+                ),
+            )
+        )
+    else:
+        out.append(Diagnostic("Audit capability", OK, "all probes have required signals"))
+    return out
+
+
 def _check_debug_log(repo: Path) -> list[Diagnostic]:
     log = repo / ".graphify_plus" / "debug.log"
     if not log.exists() or log.stat().st_size == 0:
@@ -172,6 +219,7 @@ def diagnose(repo: Path) -> list[Diagnostic]:
     out.extend(_check_system())
     out.extend(_check_cache(repo))
     out.extend(_check_skipped(repo))
+    out.extend(_check_audit_capability(repo))
     out.extend(_check_debug_log(repo))
     return out
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "graphify-plus"
-version = "5.0.3"
+version = "5.0.4"
 description = "Universal context & execution engine for AI coding agents — Tree-sitter frontend, symbol graph, skeleton CAS, MCP server."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/core/test_resolve_aliases.py
+++ b/tests/core/test_resolve_aliases.py
@@ -53,17 +53,17 @@ def test_strip_jsonc_preserves_glob_patterns_inside_strings():
     must NOT treat them as comments.
     """
     text = (
-        '{\n'
+        "{\n"
         '  "include": [\n'
         '    "**/*.ts",\n'
         '    "**/*.tsx",\n'
         '    ".next/types/**/*.ts"\n'
-        '  ],\n'
+        "  ],\n"
         '  "compilerOptions": {\n'
-        '    // a real comment\n'
+        "    // a real comment\n"
         '    "paths": {"@/*": ["./src/*"]}\n'
-        '  }\n'
-        '}\n'
+        "  }\n"
+        "}\n"
     )
     import json
 

--- a/tests/core/test_resolve_aliases.py
+++ b/tests/core/test_resolve_aliases.py
@@ -47,6 +47,39 @@ def test_strip_jsonc_handles_comments_and_trailing_commas():
     assert parsed == {"a": 1, "b": [1, 2]}
 
 
+def test_strip_jsonc_preserves_glob_patterns_inside_strings():
+    """Regression: ``"**/*.ts"`` inside an array contains characters that
+    look like the start of a block comment. The string-aware stripper
+    must NOT treat them as comments.
+    """
+    text = (
+        '{\n'
+        '  "include": [\n'
+        '    "**/*.ts",\n'
+        '    "**/*.tsx",\n'
+        '    ".next/types/**/*.ts"\n'
+        '  ],\n'
+        '  "compilerOptions": {\n'
+        '    // a real comment\n'
+        '    "paths": {"@/*": ["./src/*"]}\n'
+        '  }\n'
+        '}\n'
+    )
+    import json
+
+    parsed = json.loads(_strip_jsonc(text))
+    assert parsed["include"] == ["**/*.ts", "**/*.tsx", ".next/types/**/*.ts"]
+    assert parsed["compilerOptions"]["paths"] == {"@/*": ["./src/*"]}
+
+
+def test_strip_jsonc_respects_escaped_quotes():
+    text = '{"a": "he said \\"hi\\"", "b": "//not a comment"}'
+    import json
+
+    parsed = json.loads(_strip_jsonc(text))
+    assert parsed == {"a": 'he said "hi"', "b": "//not a comment"}
+
+
 def test_load_alias_map_reads_paths_and_baseurl(tmp_path: Path):
     _seed(tmp_path)
     am = load_alias_map(tmp_path)

--- a/tests/interface/test_doctor.py
+++ b/tests/interface/test_doctor.py
@@ -76,3 +76,20 @@ def test_doctor_cli_exit_codes(tmp_path: Path):
     )
     # No cache → ERROR diagnostic → exit 1.
     assert res2.returncode == 1
+
+
+def test_doctor_warns_about_audit_capability_gap(tmp_path: Path):
+    """A fresh `gp init` produces a graph without `community` attributes
+    or INFERRED-confidence edges; doctor should warn that 3 audit probes
+    will SKIP, BEFORE the operator runs `gp audit`."""
+    repo = _seed(tmp_path)
+    diags = diagnose(repo)
+    cap = [d for d in diags if d.section == "Audit capability"]
+    assert cap, "expected an Audit capability diagnostic"
+    # Fresh fixture has no community + no INFERRED → expect WARN with both gaps.
+    warn = next((d for d in cap if d.severity == "WARN"), None)
+    assert warn is not None, f"expected WARN, got {[d.severity for d in cap]}"
+    assert "SKIP" in warn.message
+    rem = warn.remediation or ""
+    assert "gp enrich" in rem
+    assert "community" in rem.lower()


### PR DESCRIPTION
**Regression hotfix for v5.0.3.** Caught during the Smart Energie verification.

## What broke
v5.0.3's JSONC stripper used a naive `re.compile(r'/\*.*?\*/', re.DOTALL)` regex that does not respect JSON string-literal boundaries. Real tsconfigs frequently contain glob patterns inside string values like `"**/*.ts"` — the regex sees `/*` as the start of a block comment and `*/` (across many lines, in totally unrelated array elements) as the close, destroying the JSON document. `_load_jsonc()` returned None, `load_alias_map()` returned an empty prefixes dict, and the alias resolver became a silent no-op on the very codebases it was meant to fix.

## Numbers (v5.0.3 broken vs v5.0.4 fixed, on Smart Energie)
| Metric | v5.0.3 | v5.0.4 |
|---|---|---|
| alias prefixes loaded | `{}` | `{'@/': ['src/']}` |
| imports resolved | 370 / 1624 | 1217 / 1624 (74%) |
| trust score | 55/100 | 68/100 (Grade B) |
| unresolved-imports probe | F | C |
| drift UI→data violations caught | partial (relative only) | 54 |

## Fix
Replace the regex stripper with a small character scanner that tracks `in_string` state (with `\"` escape handling) and only strips `//` / `/* */` comments OUTSIDE string literals. Trailing-comma cleanup applies to the post-strip output.

## Tests
328 passing (+2 regression tests):
- `test_strip_jsonc_preserves_glob_patterns_inside_strings` — exact reproduction of Smart Energie's tsconfig shape
- `test_strip_jsonc_respects_escaped_quotes` — handles `\"` and `//` patterns inside string values

Anyone who pulled v5.0.3 should upgrade — the alias resolver is silently broken on any tsconfig with a glob array in `include` / `exclude`. Auto-merge on CI green per project owner authorisation. Tag v5.0.4 after merge.